### PR TITLE
Wrong deprecated methods

### DIFF
--- a/Creep.js
+++ b/Creep.js
@@ -406,8 +406,6 @@ Creep.prototype =
     suicide: function() { },
 
     /**
-     * @deprecated Since version 2016-07-11
-     *
      * Transfer resource from the creep to another object.
      * The target has to be at adjacent square to the creep.
      *

--- a/Structures/StructureContainer.js
+++ b/Structures/StructureContainer.js
@@ -29,6 +29,8 @@ StructureContainer.prototype =
     storeCapacity: 0,
 
     /**
+     * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.
+     *
      * Transfer resource from this structure to a creep.
      * The target has to be at adjacent square.
      *

--- a/Structures/StructureExtension.js
+++ b/Structures/StructureExtension.js
@@ -24,6 +24,8 @@ StructureExtension.prototype =
     energyCapacity: 0,
 
     /**
+     * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.
+     *
      * Transfer the energy from the extension to a creep.
      * You can transfer resources to your creeps from hostile structures as well.
      *

--- a/Structures/StructureLab.js
+++ b/Structures/StructureLab.js
@@ -77,6 +77,8 @@ StructureLab.prototype =
     runReaction: function(lab1, lab2) { },
 
     /**
+     * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.
+     *
      * Transfer resource from this structure to a creep.
      * The target has to be at adjacent square.
      * You can transfer resources to your creeps from hostile structures as well.

--- a/Structures/StructureLink.js
+++ b/Structures/StructureLink.js
@@ -30,6 +30,8 @@ StructureLink.prototype =
     energyCapacity: 0,
 
     /**
+     * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.
+     *
      * Transfer energy from the link to another link or a creep.
      * If the target is a creep, it has to be at adjacent square to the link.
      * If the target is a link, it can be at any location in the same room.

--- a/Structures/StructurePowerSpawn.js
+++ b/Structures/StructurePowerSpawn.js
@@ -59,6 +59,8 @@ StructurePowerSpawn.prototype =
     processPower: function() { },
 
     /**
+     * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.
+     *
      * Transfer the energy from this structure to a creep.
      * You can transfer resources to your creeps from hostile structures as well.
      *

--- a/Structures/StructureSpawn.js
+++ b/Structures/StructureSpawn.js
@@ -111,6 +111,8 @@ StructureSpawn.prototype =
     renewCreep: function(target) { },
 
     /**
+     * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.
+     *
      * Transfer the energy from the spawn to a creep.
      *
      * @type {function}

--- a/Structures/StructureStorage.js
+++ b/Structures/StructureStorage.js
@@ -26,6 +26,8 @@ StructureStorage.prototype =
     storeCapacity: 0,
 
     /**
+     * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.
+     *
      * Transfer resource from this storage to a creep.
      * The target has to be at adjacent square.
      * You can transfer resources to your creeps from hostile structures as well.

--- a/Structures/StructureTerminal.js
+++ b/Structures/StructureTerminal.js
@@ -45,6 +45,8 @@ StructureTerminal.prototype =
     send: function(resourceType, amount, destination, description) { },
 
     /**
+     * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.
+     *
      * Transfer resource from this terminal to a creep.
      * The target has to be at adjacent square.
      * You can transfer resources to your creeps from hostile structures as well.

--- a/Structures/StructureTower.js
+++ b/Structures/StructureTower.js
@@ -62,6 +62,8 @@ StructureTower.prototype =
 
 
     /**
+     * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.
+     *
      * Transfer energy from the structure to a creep.
      * You can transfer resources to your creeps from hostile structures as well.
      *


### PR DESCRIPTION
As per the [official changelog](http://support.screeps.com/hc/en-us/articles/209019269-Changelog-2016-07-11) and the [`Creep` object documentation](http://support.screeps.com/hc/en-us/articles/203013212-Creep#transfer), the Creep's `transfer` method was not deprecated, only structures' methods were.

[Reference to commit](https://github.com/Garethp/ScreepsAutocomplete/commit/01c1fcd9f1917024645b487bdd3720fa46f6fb44#diff-8f34744a959b91fb471ba20e0ce09ecaR409). @Puciek @Net-burst
