### PR TITLE
StructureLink.transferEnergy() is not deprecated, as it is not replac…

### DIFF
--- a/Structures/StructureLink.js
+++ b/Structures/StructureLink.js
@@ -30,8 +30,6 @@ StructureLink.prototype =
     energyCapacity: 0,
 
     /**
-     * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.
-     *
      * Transfer energy from the link to another link or a creep.
      * If the target is a creep, it has to be at adjacent square to the link.
      * If the target is a link, it can be at any location in the same room.


### PR DESCRIPTION
…ed with Creep.withdraw().

I think someone was over-ambitious here :) 

It is true that those `transfer()` methods were replaced where a creep would withdraw energy. However, a Link is transferring energy to a different link, and thus, this method is still valid. 

Also, see the docs: http://support.screeps.com/hc/en-us/articles/208436275-StructureLink#transferEnergy
