### PR TITLE
Fixed typo for getActiveBodyparts, resolves #41

### DIFF
--- a/Creep.js
+++ b/Creep.js
@@ -220,7 +220,7 @@ Creep.prototype =
      *
      * @return {number} A number representing the quantity of body parts.
      */
-    getActiveBodyParts: function(type) { },
+    getActiveBodyparts: function(type) { },
 
     /**
      * Harvest energy from the source or minerals from the mineral deposit.


### PR DESCRIPTION
[`Creep.prototype.getActiveBodyparts`](http://support.screeps.com/hc/en-us/articles/203013212-Creep#getActiveBodyparts) should be spelt without a capital P.
