### PR TITLE
Added generateConstantsFile.js script

### DIFF
--- a/Config/generateConstantsFile.js
+++ b/Config/generateConstantsFile.js
@@ -1,0 +1,54 @@
+/**
+ * Fetches the constants library file from the master branch of the Screeps git repository, parses it, then generates
+ * and prints to stdout a file suitable for use as an autocomplete definition.
+ *
+ * USAGE:
+ * To dump the file contents to stdout:
+ * node generateConstantsFile.js
+ *
+ * To generate the Global.Constants.js file (on Linux/OSX):
+ * node generateConstantsFile.js > ../Global/Constants.js
+ *
+ * To generate the Global.Constants.js file (on Windows):
+ * https://www.ubuntu.com/download [TODO: Improve this]
+ */
+(function(){
+    "use strict";
+    const https = require("https");
+    const url = "https://raw.githubusercontent.com/screeps/common/master/lib/constants.js"
+
+    https.get(url, function (res) {
+        let body = "";
+
+        res.setEncoding("utf8");
+
+        res.on("data", data => {
+            body += data;
+        });
+
+        res.on("end", function () {
+            let fs = require("fs");
+            let tmpFileName = "constants.tmp.js";
+
+            fs.writeFile(tmpFileName, body, function (err) {
+                let constants,
+                    autocompleteContent = "";
+
+                if (err) {throw(err);}
+
+                constants = require(`./${tmpFileName}`);
+
+                Object.keys(constants).forEach(function (key) {
+                    autocompleteContent = `${autocompleteContent}\n\n/**\n * @constant\n * @type {${typeof constants[key]}}\n */`;
+                    autocompleteContent = `${autocompleteContent}\nconst ${key} = ${JSON.stringify(constants[key], null, 4)};`;
+                });
+
+                console.log(autocompleteContent);
+
+                fs.unlink(`./${tmpFileName}`, function (err) {
+                    if (err) {throw(err);}
+                });
+            });
+        });
+    });
+})();


### PR DESCRIPTION
I added a script, `Config/generateConstantsFile.js`, that will fetch the constants library file from the Screeps main repository, then parse that file and use it to generate a new `Global/Constants.js` file. 

The script doesn't replace `Global/Constants.js`, it just dumps the file contents to stdout. I'm unsure what level of automation would be desired, so I figured it would be best to at least generate the contents and let you decide on the details of the automation.