### PR TITLE
Explicitly add Room.findPath options to other methods that use them

### DIFF
--- a/Creep.js
+++ b/Creep.js
@@ -24,6 +24,8 @@ Creep.prototype =
     body: [],
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store`.
+     *
      * An object with the creep's cargo contents.
      * Each object key is one of the RESOURCE_* constants, values are resources amounts.
      * Use _.sum(creep.carry) to get the total amount of contents.
@@ -35,6 +37,8 @@ Creep.prototype =
     carry: {},
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity()`.
+     *
      * The total amount of resources the creep can carry.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/203013212-Creep#carryCapacity}
@@ -139,6 +143,15 @@ Creep.prototype =
      * @type {boolean}
      */
     spawning: false,
+
+    /**
+     * A Store object that contains cargo of this creep.
+     *
+     * @see {@link https://docs.screeps.com/api/#Creep.store}
+     *
+     * @type {Store}
+     */
+    store: {},
 
     /**
      * The remaining amount of game ticks after which the creep will die.

--- a/Creep.js
+++ b/Creep.js
@@ -344,7 +344,25 @@ Creep.prototype =
      * @param {number} [opts.reusePath] This option enables reusing the path found along multiple game ticks. It allows to save CPU time, but can result in a slightly slower creep reaction behavior. The path is stored into the creep's memory to the _move property. The reusePath value defines the amount of ticks which the path should be reused for. The default value is 5. Increase the amount to save more CPU, decrease to make the movement more consistent. Set to 0 if you want to disable path reusing.
      * @param {boolean} [opts.serializeMemory] If reusePath is enabled and this option is set to true, the path will be stored in memory in the short serialized form using Room.serializePath. The default value is true.
      * @param {boolean} [opts.noPathFinding] If this option is set to true, moveTo method will return ERR_NOT_FOUND if there is no memorized path to reuse. This can significantly save CPU time in some cases. The default value is false.
-     * @note opts also supports any method from the Room.findPath options.
+     * @param {object} [opts.visualizePathStyle] Draw a line along the creep’s path using RoomVisual.poly. You can provide either an empty object or custom style parameters.
+     * @param {string} [opts.visualizePathStyle.fill] Fill color in any web format
+     * @param {string} [opts.visualizePathStyle.stroke] Stroke color in any web format
+     * @param {string} [opts.visualizePathStyle.lineStyle] Either undefined (solid line), dashed, or dotted
+     * @param {number} [opts.visualizePathStyle.strokeWidth] Stroke line width
+     * @param {number} [opts.visualizePathStyle.opacity] Opacity value
+     * @param {boolean} [opts.ignoreCreeps] Treat squares with creeps as walkable. Can be useful with too many moving creeps around or in some other cases. The default value is false.
+     * @param {boolean} [opts.ignoreDestructibleStructures] Treat squares with destructible structures (constructed walls, ramparts, spawns, extensions) as walkable. Use this flag when you need to move through a territory blocked by hostile structures. If a creep with an ATTACK body part steps on such a square, it automatically attacks the structure. The default value is false.
+     * @param {boolean} [opts.ignoreRoads] Ignore road structures. Enabling this option can speed up the search. The default value is false. This is only used when the new PathFinder is enabled.
+     * @param {function(string, CostMatrix)} [opts.costCallback] You can use this callback to modify a CostMatrix for any room during the search. The callback accepts two arguments, roomName and costMatrix. Use the costMatrix instance to make changes to the positions costs. If you return a new matrix from this callback, it will be used instead of the built-in cached one. This option is only used when the new PathFinder is enabled.
+     * @param {Array} [opts.ignore] An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     * @param {Array} [opts.avoid] An array of the room's objects or RoomPosition objects which should be treated as obstacles during the search. This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     * @param {number} [opts.maxOps] The maximum limit of possible pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU. The default value is 2000.
+     * @param {number} [opts.heuristicWeight] Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand the underlying A* algorithm mechanics! The default value is 1.2.
+     * @param {boolean} [opts.serialize] If true, the result path will be serialized using Room.serializePath. The default is false.
+     * @param {number} [opts.maxRooms] The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new PathFinder is enabled.
+     * @param {number} [opts.range] Find a path to a position in specified linear range of target. The default is 0.
+     * @param {number} [opts.plainCost] Cost for walking on plain positions. The default is 1.
+     * @param {number} [opts.swampCost] Cost for walking on swamp positions. The default is 5.
      *
      * @alias moveTo(target, [opts])
      *

--- a/Creep.js
+++ b/Creep.js
@@ -338,7 +338,7 @@ Creep.prototype =
      *
      * @type {function}
      *
-     * @param {number} x X position of the target in the same room.
+     * @param {number|RoomPosition|RoomObject} x X position of the target in the same room.
      * @param {number} [y] Y position of the target in the same room.
      * @param {object} [opts] An object containing additional options
      * @param {number} [opts.reusePath] This option enables reusing the path found along multiple game ticks. It allows to save CPU time, but can result in a slightly slower creep reaction behavior. The path is stored into the creep's memory to the _move property. The reusePath value defines the amount of ticks which the path should be reused for. The default value is 5. Increase the amount to save more CPU, decrease to make the movement more consistent. Set to 0 if you want to disable path reusing.

--- a/Game.js
+++ b/Game.js
@@ -468,22 +468,23 @@ Game = {
         /**
          * Create a market order in your terminal.
          * You will be charged price * amount * 0.05 credits when the order is placed.
-         * The maximum orders count is 50 per player.
+         * The maximum orders count is 300 per player.
          * You can create an order at any time with any amount, it will be automatically activated and deactivated depending on the resource/credits availability.
          *
-         * @see {@link http://support.screeps.com/hc/en-us/articles/207928635-Market#createBuyOrder}
+         * @see {@link https://docs.screeps.com/api/#Game.market.createOrder}
          *
          * @type {function}
          *
-         * @param {string|ORDER_SELL|ORDER_BUY} type The order type, either ORDER_SELL or ORDER_BUY.
-         * @param {string} resourceType Either one of the RESOURCE_* constants or SUBSCRIPTION_TOKEN.
-         * @param {number} price The price for one resource unit in credits. Can be a decimal number.
-         * @param {number} totalAmount The amount of resources to be traded in total.
-         * @param {string} [roomName] The room where your order will be created. You must have your own Terminal structure in this room, otherwise the created order will be temporary inactive. This argument is not used when resourceType equals to GAMETIME_TOKEN.
+         * @param {object} params
+         * @param {string|ORDER_SELL|ORDER_BUY} params.type The order type, either ORDER_SELL or ORDER_BUY.
+         * @param {string} params.resourceType Either one of the RESOURCE_* constants or SUBSCRIPTION_TOKEN.
+         * @param {number} params.price The price for one resource unit in credits. Can be a decimal number.
+         * @param {number} params.totalAmount The amount of resources to be traded in total.
+         * @param {string} [params.roomName] The room where your order will be created. You must have your own Terminal structure in this room, otherwise the created order will be temporary inactive. This argument is not used when resourceType equals to GAMETIME_TOKEN.
          *
          * @return {number|OK|ERR_NOT_ENOUGH_RESOURCES|ERR_FULL|ERR_INVALID_ARGS}
          */
-        createOrder: function (type, resourceType, price, totalAmount, roomName) {
+        createOrder: function (params) {
         },
 
         /**

--- a/Game.js
+++ b/Game.js
@@ -525,7 +525,6 @@ Game = {
         },
 
         /**
-         * This method is still under development.
          * Get other players' orders currently active on the market.
          *
          * @see {@link http://support.screeps.com/hc/en-us/articles/207928635-Market#getAllOrders}
@@ -537,6 +536,20 @@ Game = {
          * @return {Array<Order>} An array of Orders
          */
         getAllOrders: function (filter) {
+        },
+
+        /**
+         * Get daily price history of the specified resource on the market for the last 14 days.
+         *
+         * @see {@link https://docs.screeps.com/api/#Game.market.getHistory}
+         *
+         * @type {function}
+         *
+         * @param {string} [resourceType] One of the RESOURCE_* constants. If undefined, returns history data for all resources.
+         *
+         * @return {Array<{resourceType:string, date:string, transactions:number, volume:number, avgPrice:number, stddevPrice:number}>} Returns an array of objects
+         */
+        getHistory: function (resourceType) {
         },
 
         /**

--- a/GenerateConstantsFile.js
+++ b/GenerateConstantsFile.js
@@ -1,0 +1,54 @@
+/**
+ * Fetches the constants library file from the master branch of the Screeps git repository, parses it, then generates
+ * and prints to stdout a file suitable for use as an autocomplete definition.
+ *
+ * USAGE:
+ * To dump the file contents to stdout:
+ * node generateConstantsFile.js
+ *
+ * To generate the Global.Constants.js file (on Linux/OSX):
+ * node generateConstantsFile.js > ../Global/Constants.js
+ *
+ * To generate the Global.Constants.js file (on Windows):
+ * https://www.ubuntu.com/download [TODO: Improve this]
+ */
+(function(){
+    "use strict";
+    const https = require("https");
+    const url = "https://raw.githubusercontent.com/screeps/common/master/lib/constants.js"
+
+    https.get(url, function (res) {
+        let body = "";
+
+        res.setEncoding("utf8");
+
+        res.on("data", data => {
+            body += data;
+        });
+
+        res.on("end", function () {
+            let fs = require("fs");
+            let tmpFileName = "constants.tmp.js";
+
+            fs.writeFile(tmpFileName, body, function (err) {
+                let constants,
+                    autocompleteContent = "";
+
+                if (err) {throw(err);}
+
+                constants = require(`./${tmpFileName}`);
+
+                Object.keys(constants).forEach(function (key) {
+                    autocompleteContent = `${autocompleteContent}\n\n/**\n * @constant\n * @type {${typeof constants[key]}}\n */`;
+                    autocompleteContent = `${autocompleteContent}\nconst ${key} = ${JSON.stringify(constants[key], null, 4)};`;
+                });
+
+                console.log(autocompleteContent);
+
+                fs.unlink(`./${tmpFileName}`, function (err) {
+                    if (err) {throw(err);}
+                });
+            });
+        });
+    });
+})();

--- a/GenerateRoomExt.js
+++ b/GenerateRoomExt.js
@@ -1,0 +1,81 @@
+const constants = require('./Global/ConstantsModule');
+for(let c in constants) {
+	global[c] = constants[c];
+}
+
+const singleList = [
+    STRUCTURE_OBSERVER, STRUCTURE_POWER_SPAWN, STRUCTURE_EXTRACTOR, STRUCTURE_NUKER,
+    STRUCTURE_FACTORY, STRUCTURE_INVADER_CORE, STRUCTURE_POWER_BANK,
+    //STRUCTURE_TERMINAL,   STRUCTURE_CONTROLLER,   STRUCTURE_STORAGE,
+];
+
+const multipleList = [
+    STRUCTURE_SPAWN, STRUCTURE_EXTENSION, STRUCTURE_ROAD, STRUCTURE_WALL,
+    STRUCTURE_RAMPART, STRUCTURE_KEEPER_LAIR, STRUCTURE_PORTAL, STRUCTURE_LINK,
+    STRUCTURE_TOWER, STRUCTURE_LAB, STRUCTURE_CONTAINER,
+];
+
+const singleNonStructureList = [
+    LOOK_MINERALS,
+];
+
+const multipleNonStructureList = [
+    LOOK_SOURCES, LOOK_DEPOSITS, LOOK_NUKES, LOOK_CONSTRUCTION_SITES, LOOK_TOMBSTONES,
+    LOOK_RUINS, LOOK_RESOURCES
+];
+
+console.log('Room.prototype = {');
+
+for (let type of singleList) {
+	const typeCap = type.charAt(0).toUpperCase() + type.slice(1);
+	console.log(`  /**`);
+	console.log(`   * The ${typeCap} structure of this room, if present, otherwise undefined.`)
+	console.log(`   *`);
+	console.log(`   * @see {@link https://docs.screeps.com/api/#Structure${typeCap}}`);
+	console.log(`   *`);
+	console.log(`   * @type {undefined|Structure${typeCap}}`);
+	console.log(`   */`);
+	console.log(`   ${type}: undefined,`);
+	console.log();
+}
+
+for (let type of singleNonStructureList) {
+	const typeCap = type.charAt(0).toUpperCase() + type.slice(1);
+	console.log(`  /**`);
+	console.log(`   * The ${typeCap} of this room, if present, otherwise undefined.`)
+	console.log(`   *`);
+	console.log(`   * @see {@link https://docs.screeps.com/api/#${typeCap}}`);
+	console.log(`   *`);
+	console.log(`   * @type {undefined|${typeCap}}`);
+	console.log(`   */`);
+	console.log(`   ${type}: undefined,`);
+	console.log();
+}
+
+for (let type of multipleList) {
+	const typeCap = type.charAt(0).toUpperCase() + type.slice(1);
+	console.log(`  /**`);
+	console.log(`   * All ${typeCap} structures of this room, if present, otherwise an empty array.`)
+	console.log(`   *`);
+	console.log(`   * @see {@link https://docs.screeps.com/api/#Structure${typeCap}}`);
+	console.log(`   *`);
+	console.log(`   * @type {Array<Structure${typeCap}>}`);
+	console.log(`   */`);
+	console.log(`   ${type}s: [],`);
+	console.log();
+}
+
+for (let type of multipleNonStructureList) {
+	const typeCap = type.charAt(0).toUpperCase() + type.slice(1);
+	console.log(`  /**`);
+	console.log(`   * All ${typeCap} of this room, if present, otherwise an empty array.`)
+	console.log(`   *`);
+	console.log(`   * @see {@link https://docs.screeps.com/api/#${typeCap}}`);
+	console.log(`   *`);
+	console.log(`   * @type {Array<${typeCap}>}`);
+	console.log(`   */`);
+	console.log(`   ${type}s: [],`);
+	console.log();
+}
+
+console.log('}');

--- a/Global/Constants.js
+++ b/Global/Constants.js
@@ -1,105 +1,4 @@
 
-/** CREEP BODY PARTS **/
-
-/**
- * @constant
- * @type {string}
- */
-const MOVE = "move";
-
-/**
- * @constant
- * @type {string}
- */
-const WORK = "work";
-
-/**
- * @constant
- * @type {string}
- */
-const CARRY = "carry";
-
-/**
- * @constant
- * @type {string}
- */
-const ATTACK = "attack";
-
-/**
- * @constant
- * @type {string}
- */
-const RANGED_ATTACK = "ranged_attack";
-
-/**
- * @constant
- * @type {string}
- */
-const TOUGH = "tough";
-
-/**
- * @constant
- * @type {string}
- */
-const HEAL = "heal";
-
-/**
- * @constant
- * @type {string}
- */
-const CLAIM = "claim";
-
-/** DIRECTION CONSTANTS **/
-
-/**
- * @constant
- * @type {number}
- */
-const TOP = 1;
-
-/**
- * @constant
- * @type {number}
- */
-const TOP_RIGHT = 2;
-
-/**
- * @constant
- * @type {number}
- */
-const RIGHT = 3;
-
-/**
- * @constant
- * @type {number}
- */
-const BOTTOM_RIGHT = 4;
-
-/**
- * @constant
- * @type {number}
- */
-const BOTTOM = 5;
-
-/**
- * @constant
- * @type {number}
- */
-const BOTTOM_LEFT = 6;
-
-/**
- * @constant
- * @type {number}
- */
-const LEFT = 7;
-
-/**
- * @constant
- * @type {number}
- */
-const TOP_LEFT = 8;
-
-/** ERROR CONSTANTS **/
 
 /**
  * @constant
@@ -153,12 +52,6 @@ const ERR_NOT_ENOUGH_RESOURCES = -6;
  * @constant
  * @type {number}
  */
-const ERR_NOT_ENOUGH_EXTENSIONS = -6;
-
-/**
- * @constant
- * @type {number}
- */
 const ERR_INVALID_TARGET = -7;
 
 /**
@@ -195,6 +88,12 @@ const ERR_NO_BODYPART = -12;
  * @constant
  * @type {number}
  */
+const ERR_NOT_ENOUGH_EXTENSIONS = -6;
+
+/**
+ * @constant
+ * @type {number}
+ */
 const ERR_RCL_NOT_ENOUGH = -14;
 
 /**
@@ -202,70 +101,6 @@ const ERR_RCL_NOT_ENOUGH = -14;
  * @type {number}
  */
 const ERR_GCL_NOT_ENOUGH = -15;
-
-/** COLOR CONSTANTS **/
-
-/**
- * @constant
- * @type {number}
- */
-const COLOR_RED = 1;
-
-/**
- * @constant
- * @type {number}
- */
-const COLOR_PURPLE = 2;
-
-/**
- * @constant
- * @type {number}
- */
-const COLOR_BLUE = 3;
-
-/**
- * @constant
- * @type {number}
- */
-const COLOR_CYAN = 4;
-
-/**
- * @constant
- * @type {number}
- */
-const COLOR_GREEN = 5;
-
-/**
- * @constant
- * @type {number}
- */
-const COLOR_YELLOW = 6;
-
-/**
- * @constant
- * @type {number}
- */
-const COLOR_ORANGE = 7;
-
-/**
- * @constant
- * @type {number}
- */
-const COLOR_BROWN = 8;
-
-/**
- * @constant
- * @type {number}
- */
-const COLOR_GREY = 9;
-
-/**
- * @constant
- * @type {number}
- */
-const COLOR_WHITE = 10;
-
-/** FIND CONSTANTS **/
 
 /**
  * @constant
@@ -425,47 +260,615 @@ const FIND_HOSTILE_POWER_CREEPS = 121;
 
 /**
  * @constant
- * @type {string}
+ * @type {number}
  */
-const MODE_SIMULATION = "simulation";
+const FIND_DEPOSITS = 122;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const FIND_RUINS = 123;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOP = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOP_RIGHT = 2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const RIGHT = 3;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const BOTTOM_RIGHT = 4;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const BOTTOM = 5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const BOTTOM_LEFT = 6;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LEFT = 7;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOP_LEFT = 8;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const COLOR_RED = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const COLOR_PURPLE = 2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const COLOR_BLUE = 3;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const COLOR_CYAN = 4;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const COLOR_GREEN = 5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const COLOR_YELLOW = 6;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const COLOR_ORANGE = 7;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const COLOR_BROWN = 8;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const COLOR_GREY = 9;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const COLOR_WHITE = 10;
 
 /**
  * @constant
  * @type {string}
  */
-const MODE_SURVIVAL = "survival";
+const LOOK_CREEPS = "creep";
 
 /**
  * @constant
  * @type {string}
  */
-const MODE_WORLD = "world";
+const LOOK_ENERGY = "energy";
 
 /**
  * @constant
  * @type {string}
  */
-const MODE_ARENA = "arena";
-
-/** STRUCTURE CONSTANTS **/
+const LOOK_RESOURCES = "resource";
 
 /**
  * @constant
  * @type {string}
  */
-const STRUCTURE_EXTENSION = "extension";
+const LOOK_SOURCES = "source";
 
 /**
  * @constant
  * @type {string}
  */
-const STRUCTURE_RAMPART = "rampart";
+const LOOK_MINERALS = "mineral";
 
 /**
  * @constant
  * @type {string}
  */
-const STRUCTURE_ROAD = "road";
+const LOOK_DEPOSITS = "deposit";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const LOOK_STRUCTURES = "structure";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const LOOK_FLAGS = "flag";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const LOOK_CONSTRUCTION_SITES = "constructionSite";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const LOOK_NUKES = "nuke";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const LOOK_TERRAIN = "terrain";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const LOOK_TOMBSTONES = "tombstone";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const LOOK_POWER_CREEPS = "powerCreep";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const LOOK_RUINS = "ruin";
+
+/**
+ * @constant
+ * @type {object}
+ */
+const OBSTACLE_OBJECT_TYPES = [
+    "spawn",
+    "creep",
+    "powerCreep",
+    "source",
+    "mineral",
+    "deposit",
+    "controller",
+    "constructedWall",
+    "extension",
+    "link",
+    "storage",
+    "tower",
+    "observer",
+    "powerSpawn",
+    "powerBank",
+    "lab",
+    "terminal",
+    "nuker",
+    "factory",
+    "invaderCore"
+];
+
+/**
+ * @constant
+ * @type {string}
+ */
+const MOVE = "move";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const WORK = "work";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const CARRY = "carry";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const ATTACK = "attack";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RANGED_ATTACK = "ranged_attack";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const TOUGH = "tough";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const HEAL = "heal";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const CLAIM = "claim";
+
+/**
+ * @constant
+ * @type {object}
+ */
+const BODYPART_COST = {
+    "move": 50,
+    "work": 100,
+    "attack": 80,
+    "carry": 50,
+    "heal": 250,
+    "ranged_attack": 150,
+    "tough": 10,
+    "claim": 600
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const WORLD_WIDTH = 202;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const WORLD_HEIGHT = 202;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CREEP_LIFE_TIME = 1500;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CREEP_CLAIM_LIFE_TIME = 600;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CREEP_CORPSE_RATE = 0.2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CREEP_PART_MAX_ENERGY = 125;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CARRY_CAPACITY = 50;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const HARVEST_POWER = 2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const HARVEST_MINERAL_POWER = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const HARVEST_DEPOSIT_POWER = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const REPAIR_POWER = 100;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const DISMANTLE_POWER = 50;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const BUILD_POWER = 5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const ATTACK_POWER = 30;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const UPGRADE_CONTROLLER_POWER = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const RANGED_ATTACK_POWER = 10;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const HEAL_POWER = 12;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const RANGED_HEAL_POWER = 4;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const REPAIR_COST = 0.01;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const DISMANTLE_COST = 0.005;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const RAMPART_DECAY_AMOUNT = 300;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const RAMPART_DECAY_TIME = 100;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const RAMPART_HITS = 1;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const RAMPART_HITS_MAX = {
+    "2": 300000,
+    "3": 1000000,
+    "4": 3000000,
+    "5": 10000000,
+    "6": 30000000,
+    "7": 100000000,
+    "8": 300000000
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const ENERGY_REGEN_TIME = 300;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const ENERGY_DECAY = 1000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const SPAWN_HITS = 5000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const SPAWN_ENERGY_START = 300;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const SPAWN_ENERGY_CAPACITY = 300;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CREEP_SPAWN_TIME = 3;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const SPAWN_RENEW_RATIO = 1.2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const SOURCE_ENERGY_CAPACITY = 3000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const SOURCE_ENERGY_NEUTRAL_CAPACITY = 1500;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const SOURCE_ENERGY_KEEPER_CAPACITY = 4000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const WALL_HITS = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const WALL_HITS_MAX = 300000000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EXTENSION_HITS = 1000;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const EXTENSION_ENERGY_CAPACITY = {
+    "0": 50,
+    "1": 50,
+    "2": 50,
+    "3": 50,
+    "4": 50,
+    "5": 50,
+    "6": 50,
+    "7": 100,
+    "8": 200
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const ROAD_HITS = 5000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const ROAD_WEAROUT = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const ROAD_WEAROUT_POWER_CREEP = 100;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const ROAD_DECAY_AMOUNT = 100;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const ROAD_DECAY_TIME = 1000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LINK_HITS = 1000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LINK_HITS_MAX = 1000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LINK_CAPACITY = 800;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LINK_COOLDOWN = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LINK_LOSS_RATIO = 0.03;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const STORAGE_CAPACITY = 1000000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const STORAGE_HITS = 10000;
 
 /**
  * @constant
@@ -477,13 +880,25 @@ const STRUCTURE_SPAWN = "spawn";
  * @constant
  * @type {string}
  */
+const STRUCTURE_EXTENSION = "extension";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const STRUCTURE_ROAD = "road";
+
+/**
+ * @constant
+ * @type {string}
+ */
 const STRUCTURE_WALL = "constructedWall";
 
 /**
  * @constant
  * @type {string}
  */
-const STRUCTURE_LINK = "link";
+const STRUCTURE_RAMPART = "rampart";
 
 /**
  * @constant
@@ -495,7 +910,19 @@ const STRUCTURE_KEEPER_LAIR = "keeperLair";
  * @constant
  * @type {string}
  */
+const STRUCTURE_PORTAL = "portal";
+
+/**
+ * @constant
+ * @type {string}
+ */
 const STRUCTURE_CONTROLLER = "controller";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const STRUCTURE_LINK = "link";
 
 /**
  * @constant
@@ -531,12 +958,6 @@ const STRUCTURE_POWER_SPAWN = "powerSpawn";
  * @constant
  * @type {string}
  */
-const STRUCTURE_PORTAL = "portal";
-
-/**
- * @constant
- * @type {string}
- */
 const STRUCTURE_EXTRACTOR = "extractor";
 
 /**
@@ -563,13 +984,857 @@ const STRUCTURE_CONTAINER = "container";
  */
 const STRUCTURE_NUKER = "nuker";
 
-/** RESOURCE CONSTANTS **/
+/**
+ * @constant
+ * @type {string}
+ */
+const STRUCTURE_FACTORY = "factory";
 
 /**
  * @constant
  * @type {string}
  */
-const SUBSCRIPTION_TOKEN = 'token';
+const STRUCTURE_INVADER_CORE = "invaderCore";
+
+/**
+ * @constant
+ * @type {object}
+ */
+const CONSTRUCTION_COST = {
+    "spawn": 15000,
+    "extension": 3000,
+    "road": 300,
+    "constructedWall": 1,
+    "rampart": 1,
+    "link": 5000,
+    "storage": 30000,
+    "tower": 5000,
+    "observer": 8000,
+    "powerSpawn": 100000,
+    "extractor": 5000,
+    "lab": 50000,
+    "terminal": 100000,
+    "container": 5000,
+    "nuker": 100000,
+    "factory": 100000
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONSTRUCTION_COST_ROAD_SWAMP_RATIO = 5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONSTRUCTION_COST_ROAD_WALL_RATIO = 150;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const CONTROLLER_LEVELS = {
+    "1": 200,
+    "2": 45000,
+    "3": 135000,
+    "4": 405000,
+    "5": 1215000,
+    "6": 3645000,
+    "7": 10935000
+};
+
+/**
+ * @constant
+ * @type {object}
+ */
+const CONTROLLER_STRUCTURES = {
+    "spawn": {
+        "0": 0,
+        "1": 1,
+        "2": 1,
+        "3": 1,
+        "4": 1,
+        "5": 1,
+        "6": 1,
+        "7": 2,
+        "8": 3
+    },
+    "extension": {
+        "0": 0,
+        "1": 0,
+        "2": 5,
+        "3": 10,
+        "4": 20,
+        "5": 30,
+        "6": 40,
+        "7": 50,
+        "8": 60
+    },
+    "link": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 2,
+        "6": 3,
+        "7": 4,
+        "8": 6
+    },
+    "road": {
+        "0": 2500,
+        "1": 2500,
+        "2": 2500,
+        "3": 2500,
+        "4": 2500,
+        "5": 2500,
+        "6": 2500,
+        "7": 2500,
+        "8": 2500
+    },
+    "constructedWall": {
+        "1": 0,
+        "2": 2500,
+        "3": 2500,
+        "4": 2500,
+        "5": 2500,
+        "6": 2500,
+        "7": 2500,
+        "8": 2500
+    },
+    "rampart": {
+        "1": 0,
+        "2": 2500,
+        "3": 2500,
+        "4": 2500,
+        "5": 2500,
+        "6": 2500,
+        "7": 2500,
+        "8": 2500
+    },
+    "storage": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 1,
+        "5": 1,
+        "6": 1,
+        "7": 1,
+        "8": 1
+    },
+    "tower": {
+        "1": 0,
+        "2": 0,
+        "3": 1,
+        "4": 1,
+        "5": 2,
+        "6": 2,
+        "7": 3,
+        "8": 6
+    },
+    "observer": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0,
+        "6": 0,
+        "7": 0,
+        "8": 1
+    },
+    "powerSpawn": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0,
+        "6": 0,
+        "7": 0,
+        "8": 1
+    },
+    "extractor": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0,
+        "6": 1,
+        "7": 1,
+        "8": 1
+    },
+    "terminal": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0,
+        "6": 1,
+        "7": 1,
+        "8": 1
+    },
+    "lab": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0,
+        "6": 3,
+        "7": 6,
+        "8": 10
+    },
+    "container": {
+        "0": 5,
+        "1": 5,
+        "2": 5,
+        "3": 5,
+        "4": 5,
+        "5": 5,
+        "6": 5,
+        "7": 5,
+        "8": 5
+    },
+    "nuker": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0,
+        "6": 0,
+        "7": 0,
+        "8": 1
+    },
+    "factory": {
+        "1": 0,
+        "2": 0,
+        "3": 0,
+        "4": 0,
+        "5": 0,
+        "6": 0,
+        "7": 1,
+        "8": 1
+    }
+};
+
+/**
+ * @constant
+ * @type {object}
+ */
+const CONTROLLER_DOWNGRADE = {
+    "1": 20000,
+    "2": 10000,
+    "3": 20000,
+    "4": 40000,
+    "5": 80000,
+    "6": 120000,
+    "7": 150000,
+    "8": 200000
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTROLLER_DOWNGRADE_RESTORE = 100;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTROLLER_DOWNGRADE_SAFEMODE_THRESHOLD = 5000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTROLLER_CLAIM_DOWNGRADE = 300;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTROLLER_RESERVE = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTROLLER_RESERVE_MAX = 5000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTROLLER_MAX_UPGRADE_PER_TICK = 15;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTROLLER_ATTACK_BLOCKED_UPGRADE = 1000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTROLLER_NUKE_BLOCKED_UPGRADE = 200;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const SAFE_MODE_DURATION = 20000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const SAFE_MODE_COOLDOWN = 50000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const SAFE_MODE_COST = 1000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOWER_HITS = 3000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOWER_CAPACITY = 1000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOWER_ENERGY_COST = 10;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOWER_POWER_ATTACK = 600;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOWER_POWER_HEAL = 400;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOWER_POWER_REPAIR = 800;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOWER_OPTIMAL_RANGE = 5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOWER_FALLOFF_RANGE = 20;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOWER_FALLOFF = 0.75;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const OBSERVER_HITS = 500;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const OBSERVER_RANGE = 10;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const POWER_BANK_HITS = 2000000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const POWER_BANK_CAPACITY_MAX = 5000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const POWER_BANK_CAPACITY_MIN = 500;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const POWER_BANK_CAPACITY_CRIT = 0.3;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const POWER_BANK_DECAY = 5000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const POWER_BANK_HIT_BACK = 0.5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const POWER_SPAWN_HITS = 5000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const POWER_SPAWN_ENERGY_CAPACITY = 5000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const POWER_SPAWN_POWER_CAPACITY = 100;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const POWER_SPAWN_ENERGY_RATIO = 50;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EXTRACTOR_HITS = 500;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EXTRACTOR_COOLDOWN = 5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LAB_HITS = 500;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LAB_MINERAL_CAPACITY = 3000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LAB_ENERGY_CAPACITY = 2000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LAB_BOOST_ENERGY = 20;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LAB_BOOST_MINERAL = 30;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LAB_COOLDOWN = 10;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LAB_REACTION_AMOUNT = 5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LAB_UNBOOST_ENERGY = 0;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const LAB_UNBOOST_MINERAL = 15;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const GCL_POW = 2.4;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const GCL_MULTIPLY = 1000000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const GCL_NOVICE = 3;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const MODE_SIMULATION = null;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const MODE_WORLD = null;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TERRAIN_MASK_WALL = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TERRAIN_MASK_SWAMP = 2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TERRAIN_MASK_LAVA = 4;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const MAX_CONSTRUCTION_SITES = 100;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const MAX_CREEP_SIZE = 50;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const MINERAL_REGEN_TIME = 50000;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const MINERAL_MIN_AMOUNT = {
+    "H": 35000,
+    "O": 35000,
+    "L": 35000,
+    "K": 35000,
+    "Z": 35000,
+    "U": 35000,
+    "X": 35000
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const MINERAL_RANDOM_FACTOR = 2;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const MINERAL_DENSITY = {
+    "1": 15000,
+    "2": 35000,
+    "3": 70000,
+    "4": 100000
+};
+
+/**
+ * @constant
+ * @type {object}
+ */
+const MINERAL_DENSITY_PROBABILITY = {
+    "1": 0.1,
+    "2": 0.5,
+    "3": 0.9,
+    "4": 1
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const MINERAL_DENSITY_CHANGE = 0.05;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const DENSITY_LOW = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const DENSITY_MODERATE = 2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const DENSITY_HIGH = 3;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const DENSITY_ULTRA = 4;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const DEPOSIT_EXHAUST_MULTIPLY = 0.001;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const DEPOSIT_EXHAUST_POW = 1.2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const DEPOSIT_DECAY_TIME = 50000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TERMINAL_CAPACITY = 300000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TERMINAL_HITS = 3000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TERMINAL_SEND_COST = 0.1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TERMINAL_MIN_SEND = 100;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TERMINAL_COOLDOWN = 10;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTAINER_HITS = 250000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTAINER_CAPACITY = 2000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTAINER_DECAY = 5000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTAINER_DECAY_TIME = 100;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const CONTAINER_DECAY_TIME_OWNED = 500;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const NUKER_HITS = 1000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const NUKER_COOLDOWN = 100000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const NUKER_ENERGY_CAPACITY = 300000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const NUKER_GHODIUM_CAPACITY = 5000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const NUKE_LAND_TIME = 50000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const NUKE_RANGE = 10;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const NUKE_DAMAGE = {
+    "0": 10000000,
+    "2": 5000000
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const FACTORY_HITS = 1000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const FACTORY_CAPACITY = 50000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOMBSTONE_DECAY_PER_PART = 5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const TOMBSTONE_DECAY_POWER_CREEP = 500;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const RUIN_DECAY = 500;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const RUIN_DECAY_STRUCTURES = {
+    "powerBank": 10
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const PORTAL_DECAY = 30000;
+
+/**
+ * @constant
+ * @type {string}
+ */
+const ORDER_SELL = "sell";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const ORDER_BUY = "buy";
+
+/**
+ * @constant
+ * @type {number}
+ */
+const MARKET_FEE = 0.05;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const MARKET_MAX_ORDERS = 300;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const MARKET_ORDER_LIFE_TIME = 2592000000;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const FLAGS_LIMIT = 10000;
+
+/**
+ * @constant
+ * @type {string}
+ */
+const SUBSCRIPTION_TOKEN = "token";
 
 /**
  * @constant
@@ -582,6 +1847,7 @@ const RESOURCE_ENERGY = "energy";
  * @type {string}
  */
 const RESOURCE_POWER = "power";
+
 /**
  * @constant
  * @type {string}
@@ -604,13 +1870,13 @@ const RESOURCE_UTRIUM = "U";
  * @constant
  * @type {string}
  */
-const RESOURCE_KEANIUM = "K";
+const RESOURCE_LEMERGIUM = "L";
 
 /**
  * @constant
  * @type {string}
  */
-const RESOURCE_LEMERGIUM = "L";
+const RESOURCE_KEANIUM = "K";
 
 /**
  * @constant
@@ -628,7 +1894,31 @@ const RESOURCE_CATALYST = "X";
  * @constant
  * @type {string}
  */
-const RESOURCE_OPS = "ops";
+const RESOURCE_GHODIUM = "G";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_SILICON = "silicon";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_METAL = "metal";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_BIOMASS = "biomass";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_MIST = "mist";
 
 /**
  * @constant
@@ -647,12 +1937,6 @@ const RESOURCE_ZYNTHIUM_KEANITE = "ZK";
  * @type {string}
  */
 const RESOURCE_UTRIUM_LEMERGITE = "UL";
-
-/**
- * @constant
- * @type {string}
- */
-const RESOURCE_GHODIUM = "G";
 
 /**
  * @constant
@@ -836,138 +2120,360 @@ const RESOURCE_CATALYZED_GHODIUM_ALKALIDE = "XGHO2";
 
 /**
  * @constant
+ * @type {string}
+ */
+const RESOURCE_OPS = "ops";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_UTRIUM_BAR = "utrium_bar";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_LEMERGIUM_BAR = "lemergium_bar";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_ZYNTHIUM_BAR = "zynthium_bar";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_KEANIUM_BAR = "keanium_bar";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_GHODIUM_MELT = "ghodium_melt";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_OXIDANT = "oxidant";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_REDUCTANT = "reductant";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_PURIFIER = "purifier";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_BATTERY = "battery";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_COMPOSITE = "composite";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_CRYSTAL = "crystal";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_LIQUID = "liquid";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_WIRE = "wire";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_SWITCH = "switch";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_TRANSISTOR = "transistor";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_MICROCHIP = "microchip";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_CIRCUIT = "circuit";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_DEVICE = "device";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_CELL = "cell";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_PHLEGM = "phlegm";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_TISSUE = "tissue";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_MUSCLE = "muscle";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_ORGANOID = "organoid";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_ORGANISM = "organism";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_ALLOY = "alloy";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_TUBE = "tube";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_FIXTURES = "fixtures";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_FRAME = "frame";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_HYDRAULICS = "hydraulics";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_MACHINE = "machine";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_CONDENSATE = "condensate";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_CONCENTRATE = "concentrate";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_EXTRACT = "extract";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_SPIRIT = "spirit";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_EMANATION = "emanation";
+
+/**
+ * @constant
+ * @type {string}
+ */
+const RESOURCE_ESSENCE = "essence";
+
+/**
+ * @constant
  * @type {object}
  */
 const REACTIONS = {
-    H: {
-        O: "OH",
-        L: "LH",
-        K: "KH",
-        U: "UH",
-        Z: "ZH",
-        G: "GH"
+    "H": {
+        "O": "OH",
+        "L": "LH",
+        "K": "KH",
+        "U": "UH",
+        "Z": "ZH",
+        "G": "GH"
     },
-    O: {
-        H: "OH",
-        L: "LO",
-        K: "KO",
-        U: "UO",
-        Z: "ZO",
-        G: "GO"
+    "O": {
+        "H": "OH",
+        "L": "LO",
+        "K": "KO",
+        "U": "UO",
+        "Z": "ZO",
+        "G": "GO"
     },
-    Z: {
-        K: "ZK",
-        H: "ZH",
-        O: "ZO"
+    "Z": {
+        "K": "ZK",
+        "H": "ZH",
+        "O": "ZO"
     },
-    L: {
-        U: "UL",
-        H: "LH",
-        O: "LO"
+    "L": {
+        "U": "UL",
+        "H": "LH",
+        "O": "LO"
     },
-    K: {
-        Z: "ZK",
-        H: "KH",
-        O: "KO"
+    "K": {
+        "Z": "ZK",
+        "H": "KH",
+        "O": "KO"
     },
-    G: {
-        H: "GH",
-        O: "GO"
+    "G": {
+        "H": "GH",
+        "O": "GO"
     },
-    U: {
-        L: "UL",
-        H: "UH",
-        O: "UO"
+    "U": {
+        "L": "UL",
+        "H": "UH",
+        "O": "UO"
     },
-    OH: {
-        UH: "UH2O",
-        UO: "UHO2",
-        ZH: "ZH2O",
-        ZO: "ZHO2",
-        KH: "KH2O",
-        KO: "KHO2",
-        LH: "LH2O",
-        LO: "LHO2",
-        GH: "GH2O",
-        GO: "GHO2"
+    "OH": {
+        "UH": "UH2O",
+        "UO": "UHO2",
+        "ZH": "ZH2O",
+        "ZO": "ZHO2",
+        "KH": "KH2O",
+        "KO": "KHO2",
+        "LH": "LH2O",
+        "LO": "LHO2",
+        "GH": "GH2O",
+        "GO": "GHO2"
     },
-    X: {
-        UH2O: "XUH2O",
-        UHO2: "XUHO2",
-        LH2O: "XLH2O",
-        LHO2: "XLHO2",
-        KH2O: "XKH2O",
-        KHO2: "XKHO2",
-        ZH2O: "XZH2O",
-        ZHO2: "XZHO2",
-        GH2O: "XGH2O",
-        GHO2: "XGHO2"
+    "X": {
+        "UH2O": "XUH2O",
+        "UHO2": "XUHO2",
+        "LH2O": "XLH2O",
+        "LHO2": "XLHO2",
+        "KH2O": "XKH2O",
+        "KHO2": "XKHO2",
+        "ZH2O": "XZH2O",
+        "ZHO2": "XZHO2",
+        "GH2O": "XGH2O",
+        "GHO2": "XGHO2"
     },
-    ZK: {
-        UL: "G"
+    "ZK": {
+        "UL": "G"
     },
-    UL: {
-        ZK: "G"
+    "UL": {
+        "ZK": "G"
     },
-    LH: {
-        OH: "LH2O"
+    "LH": {
+        "OH": "LH2O"
     },
-    ZH: {
-        OH: "ZH2O"
+    "ZH": {
+        "OH": "ZH2O"
     },
-    GH: {
-        OH: "GH2O"
+    "GH": {
+        "OH": "GH2O"
     },
-    KH: {
-        OH: "KH2O"
+    "KH": {
+        "OH": "KH2O"
     },
-    UH: {
-        OH: "UH2O"
+    "UH": {
+        "OH": "UH2O"
     },
-    LO: {
-        OH: "LHO2"
+    "LO": {
+        "OH": "LHO2"
     },
-    ZO: {
-        OH: "ZHO2"
+    "ZO": {
+        "OH": "ZHO2"
     },
-    KO: {
-        OH: "KHO2"
+    "KO": {
+        "OH": "KHO2"
     },
-    UO: {
-        OH: "UHO2"
+    "UO": {
+        "OH": "UHO2"
     },
-    GO: {
-        OH: "GHO2"
+    "GO": {
+        "OH": "GHO2"
     },
-    LH2O: {
-        X: "XLH2O"
+    "LH2O": {
+        "X": "XLH2O"
     },
-    KH2O: {
-        X: "XKH2O"
+    "KH2O": {
+        "X": "XKH2O"
     },
-    ZH2O: {
-        X: "XZH2O"
+    "ZH2O": {
+        "X": "XZH2O"
     },
-    UH2O: {
-        X: "XUH2O"
+    "UH2O": {
+        "X": "XUH2O"
     },
-    GH2O: {
-        X: "XGH2O"
+    "GH2O": {
+        "X": "XGH2O"
     },
-    LHO2: {
-        X: "XLHO2"
+    "LHO2": {
+        "X": "XLHO2"
     },
-    UHO2: {
-        X: "XUHO2"
+    "UHO2": {
+        "X": "XUHO2"
     },
-    KHO2: {
-        X: "XKHO2"
+    "KHO2": {
+        "X": "XKHO2"
     },
-    ZHO2: {
-        X: "XZHO2"
+    "ZHO2": {
+        "X": "XZHO2"
     },
-    GHO2: {
-        X: "XGHO2"
+    "GHO2": {
+        "X": "XGHO2"
     }
 };
 
@@ -976,1134 +2482,335 @@ const REACTIONS = {
  * @type {object}
  */
 const BOOSTS = {
-    work: {
-        UO: {
-            harvest: 2
+    "work": {
+        "UO": {
+            "harvest": 3
         },
-        UHO2: {
-            harvest: 3
+        "UHO2": {
+            "harvest": 5
         },
-        XUHO2: {
-            harvest: 4
+        "XUHO2": {
+            "harvest": 7
         },
-        LH: {
-            build: 1.3,
-            repair: 1.3
+        "LH": {
+            "build": 1.5,
+            "repair": 1.5
         },
-        LH2O: {
-            build: 1.65,
-            repair: 1.65
+        "LH2O": {
+            "build": 1.8,
+            "repair": 1.8
         },
-        XLH2O: {
-            build: 2,
-            repair: 2
+        "XLH2O": {
+            "build": 2,
+            "repair": 2
         },
-        ZH: {
-            dismantle: 2
+        "ZH": {
+            "dismantle": 2
         },
-        ZH2O: {
-            dismantle: 3
+        "ZH2O": {
+            "dismantle": 3
         },
-        XZH2O: {
-            dismantle: 4
+        "XZH2O": {
+            "dismantle": 4
         },
-        GH: {
-            upgradeController: 1.3
+        "GH": {
+            "upgradeController": 1.5
         },
-        GH2O: {
-            upgradeController: 1.65
+        "GH2O": {
+            "upgradeController": 1.8
         },
-        XGH2O: {
-            upgradeController: 2
+        "XGH2O": {
+            "upgradeController": 2
         }
     },
-    attack: {
-        UH: {
-            attack: 2
+    "attack": {
+        "UH": {
+            "attack": 2
         },
-        UH2O: {
-            attack: 3
+        "UH2O": {
+            "attack": 3
         },
-        XUH2O: {
-            attack: 4
+        "XUH2O": {
+            "attack": 4
         }
     },
-    ranged_attack: {
-        KO: {
-            rangedAttack: 2,
-            rangedMassAttack: 2
+    "ranged_attack": {
+        "KO": {
+            "rangedAttack": 2,
+            "rangedMassAttack": 2
         },
-        KHO2: {
-            rangedAttack: 3,
-            rangedMassAttack: 3
+        "KHO2": {
+            "rangedAttack": 3,
+            "rangedMassAttack": 3
         },
-        XKHO2: {
-            rangedAttack: 4,
-            rangedMassAttack: 4
+        "XKHO2": {
+            "rangedAttack": 4,
+            "rangedMassAttack": 4
         }
     },
-    heal: {
-        LO: {
-            heal: 2,
-            rangedHeal: 2
+    "heal": {
+        "LO": {
+            "heal": 2,
+            "rangedHeal": 2
         },
-        LHO2: {
-            heal: 3,
-            rangedHeal: 3
+        "LHO2": {
+            "heal": 3,
+            "rangedHeal": 3
         },
-        XLHO2: {
-            heal: 4,
-            rangedHeal: 4
+        "XLHO2": {
+            "heal": 4,
+            "rangedHeal": 4
         }
     },
-    carry: {
-        KH: {
-            capacity: 2
+    "carry": {
+        "KH": {
+            "capacity": 2
         },
-        KH2O: {
-            capacity: 3
+        "KH2O": {
+            "capacity": 3
         },
-        XKH2O: {
-            capacity: 4
+        "XKH2O": {
+            "capacity": 4
         }
     },
-    move: {
-        ZO: {
-            fatigue: 2
+    "move": {
+        "ZO": {
+            "fatigue": 2
         },
-        ZHO2: {
-            fatigue: 3
+        "ZHO2": {
+            "fatigue": 3
         },
-        XZHO2: {
-            fatigue: 4
+        "XZHO2": {
+            "fatigue": 4
         }
     },
-    tough: {
-        GO: {
-            damage: .7
+    "tough": {
+        "GO": {
+            "damage": 0.7
         },
-        GHO2: {
-            damage: .5
+        "GHO2": {
+            "damage": 0.5
         },
-        XGHO2: {
-            damage: .3
+        "XGHO2": {
+            "damage": 0.3
         }
     }
 };
 
 /**
  * @constant
- * @type {string[]}
+ * @type {object}
  */
-const RESOURCES_ALL = [
-    RESOURCE_ENERGY,
-    RESOURCE_POWER,
-    RESOURCE_HYDROGEN,
-    RESOURCE_OXYGEN,
-    RESOURCE_UTRIUM,
-    RESOURCE_KEANIUM,
-    RESOURCE_LEMERGIUM,
-    RESOURCE_ZYNTHIUM,
-    RESOURCE_CATALYST,
-    RESOURCE_GHODIUM,
-    RESOURCE_HYDROXIDE,
-    RESOURCE_ZYNTHIUM_KEANITE,
-    RESOURCE_UTRIUM_LEMERGITE,
-    RESOURCE_UTRIUM_HYDRIDE,
-    RESOURCE_UTRIUM_OXIDE,
-    RESOURCE_KEANIUM_HYDRIDE,
-    RESOURCE_KEANIUM_OXIDE,
-    RESOURCE_LEMERGIUM_HYDRIDE,
-    RESOURCE_LEMERGIUM_OXIDE,
-    RESOURCE_ZYNTHIUM_HYDRIDE,
-    RESOURCE_ZYNTHIUM_OXIDE,
-    RESOURCE_GHODIUM_HYDRIDE,
-    RESOURCE_GHODIUM_OXIDE,
-    RESOURCE_UTRIUM_ACID,
-    RESOURCE_UTRIUM_ALKALIDE,
-    RESOURCE_KEANIUM_ACID,
-    RESOURCE_KEANIUM_ALKALIDE,
-    RESOURCE_LEMERGIUM_ACID,
-    RESOURCE_LEMERGIUM_ALKALIDE,
-    RESOURCE_ZYNTHIUM_ACID,
-    RESOURCE_ZYNTHIUM_ALKALIDE,
-    RESOURCE_GHODIUM_ACID,
-    RESOURCE_GHODIUM_ALKALIDE,
-    RESOURCE_CATALYZED_UTRIUM_ACID,
-    RESOURCE_CATALYZED_UTRIUM_ALKALIDE,
-    RESOURCE_CATALYZED_KEANIUM_ACID,
-    RESOURCE_CATALYZED_KEANIUM_ALKALIDE,
-    RESOURCE_CATALYZED_LEMERGIUM_ACID,
-    RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE,
-    RESOURCE_CATALYZED_ZYNTHIUM_ACID,
-    RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE,
-    RESOURCE_CATALYZED_GHODIUM_ACID,
-    RESOURCE_CATALYZED_GHODIUM_ALKALIDE,
-    RESOURCE_OPS
-];
-
-/**
- * @constant
- * @type {string[]}
- */
-const BODYPARTS_ALL = [
-    MOVE,
-    WORK,
-    CARRY,
-    ATTACK,
-    RANGED_ATTACK,
-    TOUGH,
-    HEAL,
-    CLAIM
-];
-
-/**
- * @constant
- * @type {string[]}
- */
-const COLORS_ALL = [
-    COLOR_RED,
-    COLOR_PURPLE,
-    COLOR_BLUE,
-    COLOR_CYAN,
-    COLOR_GREEN,
-    COLOR_YELLOW,
-    COLOR_ORANGE,
-    COLOR_BROWN,
-    COLOR_GREY,
-    COLOR_WHITE
-];
-
 const REACTION_TIME = {
-    OH: 20,
-    ZK: 5,
-    UL: 5,
-    G: 5,
-    UH: 10,
-    UH2O: 5,
-    XUH2O: 60,
-    UO: 10,
-    UHO2: 5,
-    XUHO2: 60,
-    KH: 10,
-    KH2O: 5,
-    XKH2O: 60,
-    KO: 10,
-    KHO2: 5,
-    XKHO2: 60,
-    LH: 15,
-    LH2O: 10,
-    XLH2O: 65,
-    LO: 10,
-    LHO2: 5,
-    XLHO2: 60,
-    ZH: 20,
-    ZH2O: 40,
-    XZH2O: 160,
-    ZO: 10,
-    ZHO2: 5,
-    XZHO2: 60,
-    GH: 10,
-    GH2O: 15,
-    XGH2O: 80,
-    GO: 10,
-    GHO2: 30,
-    XGHO2: 150,
-};
-
-/**
- * @constant
- * @type {object}
- */
-const BODYPART_COST = {
-    move:           50,
-    work:          100,
-    attack:         80,
-    carry:          50,
-    heal:          250,
-    ranged_attack: 150,
-    tough:          10,
-    claim:         600
-};
-
-/**
- * Spawn time per body part in ticks
- * @constant
- * @type {number}
- */
-const CREEP_SPAWN_TIME = 3;
-
-/**
- * @constant
- * @type {number}
- */
-const CREEP_RENEW_RATIO = 1.2;
-
-/**
- * Lifetime of a creep
- * @constant
- * @type {number}
- */
-const CREEP_LIFE_TIME = 1500;
-
-/**
- * Lifetime of a creep with CLAIM body parts
- * @constant
- * @type {number}
- */
-const CREEP_CLAIM_LIFE_TIME = 500;
-
-/**
- * use unknown
- * @constant
- * @type {number}
- */
-const CREEP_CORPSE_RATE = 0.2;
-
-/**
- * @constant
- * @type {string[]}
- */
-const OBSTACLE_OBJECT_TYPES = ["spawn", "creep", "powerCreep", "source", "mineral", "controller", "constructedWall", "extension", "link", "storage", "tower", "observer", "powerSpawn", "powerBank", "lab", "terminal","nuker"];
-
-/**
- * @constant
- * @type {number}
- */
-const ENERGY_REGEN_TIME = 300;
-
-/**
- * @constant
- * @type {number}
- */
-const ENERGY_DECAY = 1000;
-
-/**
- * @constant
- * @type {number}
- */
-const MINERAL_REGEN_TIME = 50000;
-
-/**
- * @constant
- * @type {object}
- */
-const MINERAL_MIN_AMOUNT = {
-    H: 140000,
-    O: 140000,
-    L: 70000,
-    K: 70000,
-    Z: 70000,
-    U: 70000,
-    X: 70000
+    "OH": 20,
+    "ZK": 5,
+    "UL": 5,
+    "G": 5,
+    "UH": 10,
+    "UH2O": 5,
+    "XUH2O": 60,
+    "UO": 10,
+    "UHO2": 5,
+    "XUHO2": 60,
+    "KH": 10,
+    "KH2O": 5,
+    "XKH2O": 60,
+    "KO": 10,
+    "KHO2": 5,
+    "XKHO2": 60,
+    "LH": 15,
+    "LH2O": 10,
+    "XLH2O": 65,
+    "LO": 10,
+    "LHO2": 5,
+    "XLHO2": 60,
+    "ZH": 20,
+    "ZH2O": 40,
+    "XZH2O": 160,
+    "ZO": 10,
+    "ZHO2": 5,
+    "XZHO2": 60,
+    "GH": 10,
+    "GH2O": 15,
+    "XGH2O": 80,
+    "GO": 10,
+    "GHO2": 30,
+    "XGHO2": 150
 };
 
 /**
  * @constant
  * @type {number}
  */
-const MINERAL_RANDOM_FACTOR = 2;
+const PORTAL_UNSTABLE = 864000000;
 
 /**
  * @constant
  * @type {number}
  */
-const REPAIR_COST = 0.01;
+const PORTAL_MIN_TIMEOUT = 1036800000;
 
 /**
  * @constant
  * @type {number}
  */
-const DISMANTLE_COST = 0.005;
+const PORTAL_MAX_TIMEOUT = 1900800000;
 
 /**
  * @constant
  * @type {number}
  */
-const RAMPART_DECAY_AMOUNT = 300;
+const POWER_BANK_RESPAWN_TIME = 50000;
 
 /**
  * @constant
  * @type {number}
  */
-const RAMPART_DECAY_TIME = 100;
-
-/**
- * @constant
- * @type {number}
- */
-const RAMPART_HITS = 1;
-
-/**
- * @constant
- * @type {object}
- */
-const RAMPART_HITS_MAX = {
-    2: 300000,
-    3: 1000000,
-    4: 3000000,
-    5: 10000000,
-    6: 30000000,
-    7: 100000000,
-    8: 300000000
-};
-
-/**
- * @constant
- * @type {number}
- */
-const SPAWN_HITS = 5000;
-
-/**
- * @constant
- * @type {number}
- */
-const SPAWN_ENERGY_START = 300;
-
-/**
- * @constant
- * @type {number}
- */
-const SPAWN_ENERGY_CAPACITY = 300;
-
-/**
- * @constant
- * @type {number}
- */
-const SOURCE_ENERGY_CAPACITY = 3000;
-
-/**
- * @constant
- * @type {number}
- */
-const SOURCE_ENERGY_NEUTRAL_CAPACITY = 1500;
-
-/**
- * @constant
- * @type {number}
- */
-const SOURCE_ENERGY_KEEPER_CAPACITY = 4500;
-
-/**
- * @constant
- * @type {number}
- */
-const ROAD_HITS = 5000;
-
-/**
- * @constant
- * @type {number}
- */
-const WALL_HITS = 1;
-
-/**
- * @constant
- * @type {number}
- */
-const WALL_HITS_MAX = 300000000;
-
-/**
- * @constant
- * @type {number}
- */
-const EXTENSION_HITS = 1000;
-
-/**
- * @constant
- * @type {object}
- */
-const EXTENSION_ENERGY_CAPACITY = {
-    0: 50,
-    1: 50,
-    2: 50,
-    3: 50,
-    4: 50,
-    5: 50,
-    6: 50,
-    7: 100,
-    8: 200
-};
-
-/**
- * @constant
- * @type {number}
- */
-const ROAD_WEAROUT = 1;
-
-/**
- * @constant
- * @type {number}
- */
-const ROAD_DECAY_AMOUNT = 100;
-
-/**
- * @constant
- * @type {number}
- */
-const ROAD_DECAY_TIME = 1000;
-
-/**
- * @constant
- * @type {number}
- */
-const LINK_HITS = 1000;
-
-/**
- * @constant
- * @type {number}
- */
-const LINK_HITS_MAX = 1000;
-
-/**
- * @constant
- * @type {number}
- */
-const LINK_CAPACITY = 800;
-
-/**
- * @constant
- * @type {number}
- */
-const LINK_COOLDOWN = 1;
-
-/**
- * @constant
- * @type {number}
- */
-const LINK_LOSS_RATIO = 0.03;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTAINER_HITS = 250000;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTAINER_CAPACITY = 2000;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTAINER_DECAY = 5000;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTAINER_DECAY_TIME = 100;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTAINER_DECAY_TIME_OWNED = 500;
-
-/**
- * @constant
- * @type {number}
- */
-const NUKER_HITS = 1000;
-
-/**
- * @constant
- * @type {number}
- */
-const NUKER_COOLDOWN = 100000;
-
-/**
- * @constant
- * @type {number}
- */
-const NUKER_ENERGY_CAPACITY = 300000;
-
-/**
- * @constant
- * @type {number}
- */
-const NUKER_GHODIUM_CAPACITY = 5000;
-
-/**
- * @constant
- * @type {number}
- */
-const NUKE_LAND_TIME = 50000;
-
-/**
- * @constant
- * @type {number}
- */
-const NUKE_RANGE = 10;
-
-/**
- * @constant
- * @type {object}
- */
-const NUKE_DAMAGE = {
-    0: 10000000,
-    2: 5000000
-};
-
-/**
- * @constant
- * @type {number}
- */
-const PORTAL_DECAY = 30000;
-
-/**
- * @constant
- * @type {number}
- */
-const TOMBSTONE_DECAY_PER_PART = 5;
+const INVADERS_ENERGY_GOAL = 100000;
 
 /**
  * @constant
  * @type {string}
  */
-const ORDER_SELL = 'sell';
+const SYSTEM_USERNAME = "Screeps";
 
 /**
  * @constant
  * @type {string}
  */
-const ORDER_BUY = 'buy';
-
-/**
- * @constant
- * @type {number}
- */
-const STORAGE_CAPACITY = 1000000;
-
-/**
- * @constant
- * @type {number}
- */
-const STORAGE_HITS = 10000;
-
-/**
- * @constant
- * @type {number}
- */
-const CARRY_CAPACITY = 50;
-
-/**
- * @constant
- * @type {number}
- */
-const HARVEST_POWER = 2;
-
-/**
- * @constant
- * @type {number}
- */
-const HARVEST_MINERAL_POWER = 1;
-
-/**
- * @constant
- * @type {number}
- */
-const REPAIR_POWER = 100;
-
-/**
- * @constant
- * @type {number}
- */
-const DISMANTLE_POWER = 100;
-
-/**
- * @constant
- * @type {number}
- */
-const BUILD_POWER = 5;
-
-/**
- * @constant
- * @type {number}
- */
-const ATTACK_POWER = 30;
-
-/**
- * @constant
- * @type {number}
- */
-const UPGRADE_CONTROLLER_POWER = 1;
-
-/**
- * @constant
- * @type {number}
- */
-const RANGED_ATTACK_POWER = 10;
-
-/**
- * @constant
- * @type {number}
- */
-const HEAL_POWER = 12;
-
-/**
- * @constant
- * @type {number}
- */
-const RANGED_HEAL_POWER = 4;
-
-/**
- * @constant
- * @type {object}
- */
-const CONSTRUCTION_COST = {
-    spawn: 15000,
-    extension: 3000,
-    road: 300,
-    constructedWall: 1,
-    rampart: 1,
-    link: 5000,
-    storage: 30000,
-    tower: 5000,
-    observer: 8000,
-    powerSpawn: 100000,
-    extractor: 5000,
-    lab: 50000,
-    terminal: 100000,
-    container: 5000,
-    nuker: 100000
-};
-
-/**
- * @constant
- * @type {number}
- */
-const CONSTRUCTION_COST_ROAD_SWAMP_RATIO = 5;
-
-/**
- * @constant
- * @type {object}
- */
-const CONTROLLER_LEVELS = {
-    1: 200,
-    2: 45000,
-    3: 135000,
-    4: 405000,
-    5: 1215000,
-    6: 3645000,
-    7: 10935000
-};
-
-/**
- * @constant
- * @type {object}
- */
-const CONTROLLER_STRUCTURES = {
-    spawn: { 0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 2, 8: 3 },
-    extension: { 0: 0, 1: 0, 2: 5, 3: 10, 4: 20, 5: 30, 6: 40, 7: 50, 8: 60 },
-    link: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 2, 6: 3, 7: 4, 8: 6 },
-    road: { 0: 2500, 1: 2500, 2: 2500, 3: 2500, 4: 2500, 5: 2500, 6: 2500, 7: 2500, 8: 2500 },
-    constructedWall: { 1: 0, 2: 2500, 3: 2500, 4: 2500, 5: 2500, 6: 2500, 7: 2500, 8: 2500 },
-    rampart: { 1: 0, 2: 2500, 3: 2500, 4: 2500, 5: 2500, 6: 2500, 7: 2500, 8: 2500 },
-    storage: { 1: 0, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1 },
-    tower: { 1: 0, 2: 0, 3: 1, 4: 1, 5: 1, 6: 2, 7: 2, 8: 4 },
-    observer: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 1 },
-    powerSpawn: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 1 }
-};
-
-/**
- * @constant
- * @type {object}
- */
-const CONTROLLER_DOWNGRADE = {
-    1: 20000,
-    2: 5000,
-    3: 10000,
-    4: 20000,
-    5: 40000,
-    6: 60000,
-    7: 100000,
-    8: 150000
-};
-
-/**
- * @constant
- * @type {number}
- */
-const CONTROLLER_DOWNGRADE_RESTORE = 100;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTROLLER_DOWNGRADE_SAFEMODE_THRESHOLD = 5000;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTROLLER_CLAIM_DOWNGRADE = 0.2;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTROLLER_RESERVE = 1;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTROLLER_RESERVE_MAX = 5000;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTROLLER_MAX_UPGRADE_PER_TICK = 15;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTROLLER_ATTACK_BLOCKED_UPGRADE = 1000;
-
-/**
- * @constant
- * @type {number}
- */
-const CONTROLLER_NUKE_BLOCKED_UPGRADE = 200;
-
-/**
- * @constant
- * @type {number}
- */
-const TERMINAL_CAPACITY = 300000;
-
-/**
- * @constant
- * @type {number}
- */
-const TERMINAL_HITS = 3000;
-
-/**
- * @constant
- * @type {number}
- */
-const TERMINAL_SEND_COST = 0.1;
-
-/**
- * @constant
- * @type {number}
- */
-const TERMINAL_MIN_SEND = 100;
-
-/**
- * @constant
- * @type {number}
- */
-const TOWER_HITS = 3000;
-
-/**
- * @constant
- * @type {number}
- */
-const TOWER_CAPACITY = 1000;
-
-/**
- * @constant
- * @type {number}
- */
-const TOWER_ENERGY_COST = 10;
-
-/**
- * @constant
- * @type {number}
- */
-const TOWER_POWER_ATTACK = 600;
-
-/**
- * @constant
- * @type {number}
- */
-const TOWER_POWER_HEAL = 400;
-
-/**
- * @constant
- * @type {number}
- */
-const TOWER_POWER_REPAIR = 800;
-
-/**
- * @constant
- * @type {number}
- */
-const TOWER_OPTIMAL_RANGE = 5;
-
-/**
- * @constant
- * @type {number}
- */
-const TOWER_FALLOFF_RANGE = 20;
-
-/**
- * @constant
- * @type {number}
- */
-const TOWER_FALLOFF = 0.75;
-
-/**
- * @constant
- * @type {number}
- */
-const OBSERVER_HITS = 500;
-
-/**
- * @constant
- * @type {number}
- */
-const OBSERVER_RANGE = 10;
-
-/**
- * @constant
- * @type {number}
- */
-const POWER_BANK_HITS = 2000000;
-
-/**
- * @constant
- * @type {number}
- */
-const POWER_BANK_CAPACITY_MAX = 5000;
-
-/**
- * @constant
- * @type {number}
- */
-const POWER_BANK_CAPACITY_MIN = 500;
-
-/**
- * @constant
- * @type {number}
- */
-const POWER_BANK_CAPACITY_CRIT = 0.3;
-
-/**
- * @constant
- * @type {number}
- */
-const POWER_BANK_DECAY = 5000;
-
-/**
- * @constant
- * @type {number}
- */
-const POWER_BANK_HIT_BACK = 0.5;
-
-/**
- * @constant
- * @type {number}
- */
-const POWER_SPAWN_HITS = 5000;
-
-/**
- * @constant
- * @type {number}
- */
-const POWER_SPAWN_ENERGY_CAPACITY = 5000;
-
-/**
- * @constant
- * @type {number}
- */
-const POWER_SPAWN_POWER_CAPACITY = 100;
-
-/**
- * @constant
- * @type {number}
- */
-const POWER_SPAWN_ENERGY_RATIO = 50;
-
-/**
- * @constant
- * @type {number}
- */
-const LAB_HITS = 500;
-
-/**
- * @constant
- * @type {number}
- */
-const LAB_MINERAL_CAPACITY = 3000;
-
-/**
- * @constant
- * @type {number}
- */
-const LAB_ENERGY_CAPACITY = 2000;
-
-/**
- * @constant
- * @type {number}
- */
-const LAB_BOOST_ENERGY = 20;
-
-/**
- * @constant
- * @type {number}
- */
-const LAB_BOOST_MINERAL = 30;
-
-/**
- * @constant
- * @type {number}
- */
-const LAB_COOLDOWN = 10;
-
-/**
- * @constant
- * @type {number}
- */
-const GCL_POW = 2.4;
-
-/**
- * @constant
- * @type {number}
- */
-const GCL_MULTIPLY = 1000000;
-
-/**
- * @constant
- * @type {number}
- */
-const GCL_NOVICE = 3;
-
-/**
- * @constant
- * @type {number}
- */
-const TERRAIN_MASK_WALL = 1;
-
-/**
- * @constant
- * @type {number}
- */
-const TERRAIN_MASK_SWAMP = 2;
-
-/**
- * @constant
- * @type {number}
- */
-const TERRAIN_MASK_LAVA = 4;
-
-/**
- * @constant
- * @type {number}
- */
-const MAX_CONSTRUCTION_SITES = 100;
-
-/**
- * @constant
- * @type {number}
- */
-const MAX_CREEP_SIZE = 50;
-
-/** LOOK CONSTANTS **/
+const SIGN_NOVICE_AREA = "A new Novice or Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.";
 
 /**
  * @constant
  * @type {string}
  */
-const LOOK_CREEPS = "creep";
+const SIGN_RESPAWN_AREA = "A new Novice or Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.";
 
 /**
  * @constant
  * @type {string}
  */
-const LOOK_ENERGY = "energy";
-
-/**
- * @constant
- * @type {string}
- */
-const LOOK_RESOURCES = "resource";
-
-/**
- * @constant
- * @type {string}
- */
-const LOOK_SOURCES = "source";
-
-/**
- * @constant
- * @type {string}
- */
-const LOOK_MINERALS = "mineral";
-
-/**
- * @constant
- * @type {string}
- */
-const LOOK_STRUCTURES = "structure";
-
-/**
- * @constant
- * @type {string}
- */
-const LOOK_FLAGS = "flag";
-
-/**
- * @constant
- * @type {string}
- */
-const LOOK_CONSTRUCTION_SITES = "constructionSite";
-
-/**
- * @constant
- * @type {string}
- */
-const LOOK_NUKES = "nuke";
-
-/**
- * @constant
- * @type {string}
- */
-const LOOK_TERRAIN = "terrain";
-
-/**
- * @constant
- * @type {string}
- */
-const LOOK_TOMBSTONES = "tombstone";
-
-/**
- * @constant
- * @type {string}
- */
-const SYSTEM_USERNAME = 'Screeps';
-
-/**
- * @constant
- * @deprecated use SIGN_PLANNED_AREA instead.
- * @type {string}
- */
-const SIGN_NOVICE_AREA = 'A new Novice Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.';
-
-/**
- * @constant
- * @deprecated use SIGN_PLANNED_AREA instead.
- * @type {string}
- */
-const SIGN_RESPAWN_AREA = 'A new Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.';
-
-/**
- * @constant
- * @type {string}
- */
-const SIGN_PLANNED_AREA = 'A new Novice or Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.';
+const SIGN_PLANNED_AREA = "A new Novice or Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.";
 
 /**
  * @constant
  * @type {number}
  */
-const TERMINAL_COOLDOWN = 10;
+const EVENT_ATTACK = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_OBJECT_DESTROYED = 2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_ATTACK_CONTROLLER = 3;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_BUILD = 4;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_HARVEST = 5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_HEAL = 6;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_REPAIR = 7;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_RESERVE_CONTROLLER = 8;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_UPGRADE_CONTROLLER = 9;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_EXIT = 10;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_POWER = 11;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_TRANSFER = 12;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_ATTACK_TYPE_MELEE = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_ATTACK_TYPE_RANGED = 2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_ATTACK_TYPE_RANGED_MASS = 3;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_ATTACK_TYPE_DISMANTLE = 4;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_ATTACK_TYPE_HIT_BACK = 5;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_ATTACK_TYPE_NUKE = 6;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_HEAL_TYPE_MELEE = 1;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EVENT_HEAL_TYPE_RANGED = 2;
 
 /**
  * @constant
@@ -2121,13 +2828,13 @@ const POWER_LEVEL_POW = 2;
  * @constant
  * @type {number}
  */
-const POWER_CREEP_SPAWN_COOLDOWN = 8*3600*1000;
+const POWER_CREEP_SPAWN_COOLDOWN = 28800000;
 
 /**
  * @constant
  * @type {number}
  */
-const POWER_CREEP_DELETE_COOLDOWN = 24*3600*1000;
+const POWER_CREEP_DELETE_COOLDOWN = 86400000;
 
 /**
  * @constant
@@ -2145,7 +2852,9 @@ const POWER_CREEP_LIFE_TIME = 5000;
  * @constant
  * @type {object}
  */
-const POWER_CLASS = { OPERATOR: 'operator' };
+const POWER_CLASS = {
+    "OPERATOR": "operator"
+};
 
 /**
  * @constant
@@ -2263,168 +2972,1042 @@ const PWR_OPERATE_FACTORY = 19;
 
 /**
  * @constant
+ * @type {number}
+ */
+const EFFECT_INVULNERABILITY = 1001;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const EFFECT_COLLAPSE_TIMER = 1002;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const INVADER_CORE_HITS = 100000;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const INVADER_CORE_CREEP_SPAWN_TIME = {
+    "0": 0,
+    "1": 0,
+    "2": 6,
+    "3": 3,
+    "4": 2,
+    "5": 1
+};
+
+/**
+ * @constant
+ * @type {object}
+ */
+const INVADER_CORE_EXPAND_TIME = {
+    "1": 4000,
+    "2": 3500,
+    "3": 3000,
+    "4": 2500,
+    "5": 2000
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const INVADER_CORE_CONTROLLER_POWER = 2;
+
+/**
+ * @constant
+ * @type {number}
+ */
+const INVADER_CORE_CONTROLLER_DOWNGRADE = 5000;
+
+/**
+ * @constant
+ * @type {object}
+ */
+const STRONGHOLD_RAMPART_HITS = {
+    "0": 0,
+    "1": 100000,
+    "2": 200000,
+    "3": 500000,
+    "4": 1000000,
+    "5": 2000000
+};
+
+/**
+ * @constant
+ * @type {number}
+ */
+const STRONGHOLD_DECAY_TICKS = 75000;
+
+/**
+ * @constant
  * @type {object}
  */
 const POWER_INFO = {
-        [exports.PWR_GENERATE_OPS]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 50,
-            effect: [1, 2, 4, 6, 8]
-        },
-        [exports.PWR_OPERATE_SPAWN]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 300,
-            duration: 1000,
-            range: 3,
-            ops: 100,
-            effect: [0.9, 0.7, 0.5, 0.35, 0.2]
-        },
-        [exports.PWR_OPERATE_TOWER]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 10,
-            duration: 100,
-            range: 3,
-            ops: 10,
-            effect: [1.1, 1.2, 1.3, 1.4, 1.5]
-        },
-        [exports.PWR_OPERATE_STORAGE]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 800,
-            duration: 1000,
-            range: 3,
-            ops: 100,
-            effect: [500000,1000000,2000000,4000000,7000000]
-        },
-        [exports.PWR_OPERATE_LAB]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 50,
-            duration: 1000,
-            range: 3,
-            ops: 10,
-            effect: [2,4,6,8,10]
-        },
-        [exports.PWR_OPERATE_EXTENSION]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 50,
-            range: 3,
-            ops: 2,
-            effect: [0.2, 0.4, 0.6, 0.8, 1.0]
-        },
-        [exports.PWR_OPERATE_OBSERVER]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 400,
-            duration: [200,400,600,800,1000],
-            range: 3,
-            ops: 10,
-        },
-        [exports.PWR_OPERATE_TERMINAL]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 500,
-            duration: 1000,
-            range: 3,
-            ops: 100,
-            effect: [0.9, 0.8, 0.7, 0.6, 0.5]
-        },
-        [exports.PWR_DISRUPT_SPAWN]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 5,
-            range: 20,
-            ops: 10,
-            duration: [1,2,3,4,5]
-        },
-        [exports.PWR_DISRUPT_TOWER]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 0,
-            duration: 5,
-            range: 3,
-            ops: 10,
-            effect: [0.9, 0.8, 0.7, 0.6, 0.5],
-        },
-        [exports.PWR_DISRUPT_SOURCE]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 100,
-            range: 3,
-            ops: 100,
-            duration: [100, 200, 300, 400, 500]
-        },
-        [exports.PWR_SHIELD]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            effect: [5000, 10000, 15000, 20000, 25000],
-            duration: 50,
-            cooldown: 20,
-            energy: 100,
-        },
-        [exports.PWR_REGEN_SOURCE]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [10, 11, 12, 14, 22],
-            cooldown: 100,
-            duration: 300,
-            range: 3,
-            effect: [50,100,150,200,250],
-            period: 15
-        },
-        [exports.PWR_REGEN_MINERAL]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [10, 11, 12, 14, 22],
-            cooldown: 100,
-            duration: 100,
-            range: 3,
-            effect: [2,4,6,8,10],
-            period: 10
-        },
-        [exports.PWR_DISRUPT_TERMINAL]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [20, 21, 22, 23, 24],
-            cooldown: 8,
-            duration: 10,
-            range: 50,
-            ops: [50,40,30,20,10]
+    "1": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 50,
+        "effect": [
+            1,
+            2,
+            4,
+            6,
+            8
+        ]
+    },
+    "2": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 300,
+        "duration": 1000,
+        "range": 3,
+        "ops": 100,
+        "effect": [
+            0.9,
+            0.7,
+            0.5,
+            0.35,
+            0.2
+        ]
+    },
+    "3": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 10,
+        "duration": 100,
+        "range": 3,
+        "ops": 10,
+        "effect": [
+            1.1,
+            1.2,
+            1.3,
+            1.4,
+            1.5
+        ]
+    },
+    "4": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 800,
+        "duration": 1000,
+        "range": 3,
+        "ops": 100,
+        "effect": [
+            500000,
+            1000000,
+            2000000,
+            4000000,
+            7000000
+        ]
+    },
+    "5": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 50,
+        "duration": 1000,
+        "range": 3,
+        "ops": 10,
+        "effect": [
+            2,
+            4,
+            6,
+            8,
+            10
+        ]
+    },
+    "6": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 50,
+        "range": 3,
+        "ops": 2,
+        "effect": [
+            0.2,
+            0.4,
+            0.6,
+            0.8,
+            1
+        ]
+    },
+    "7": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 400,
+        "duration": [
+            200,
+            400,
+            600,
+            800,
+            1000
+        ],
+        "range": 3,
+        "ops": 10
+    },
+    "8": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 500,
+        "duration": 1000,
+        "range": 3,
+        "ops": 100,
+        "effect": [
+            0.9,
+            0.8,
+            0.7,
+            0.6,
+            0.5
+        ]
+    },
+    "9": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 5,
+        "range": 20,
+        "ops": 10,
+        "duration": [
+            1,
+            2,
+            3,
+            4,
+            5
+        ]
+    },
+    "10": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 0,
+        "duration": 5,
+        "range": 50,
+        "ops": 10,
+        "effect": [
+            0.9,
+            0.8,
+            0.7,
+            0.6,
+            0.5
+        ]
+    },
+    "11": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 100,
+        "range": 3,
+        "ops": 100,
+        "duration": [
+            100,
+            200,
+            300,
+            400,
+            500
+        ]
+    },
+    "12": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "effect": [
+            5000,
+            10000,
+            15000,
+            20000,
+            25000
+        ],
+        "duration": 50,
+        "cooldown": 20,
+        "energy": 100
+    },
+    "13": {
+        "className": "operator",
+        "level": [
+            10,
+            11,
+            12,
+            14,
+            22
+        ],
+        "cooldown": 100,
+        "duration": 300,
+        "range": 3,
+        "effect": [
+            50,
+            100,
+            150,
+            200,
+            250
+        ],
+        "period": 15
+    },
+    "14": {
+        "className": "operator",
+        "level": [
+            10,
+            11,
+            12,
+            14,
+            22
+        ],
+        "cooldown": 100,
+        "duration": 100,
+        "range": 3,
+        "effect": [
+            2,
+            4,
+            6,
+            8,
+            10
+        ],
+        "period": 10
+    },
+    "15": {
+        "className": "operator",
+        "level": [
+            20,
+            21,
+            22,
+            23,
+            24
+        ],
+        "cooldown": 8,
+        "duration": 10,
+        "range": 50,
+        "ops": [
+            50,
+            40,
+            30,
+            20,
+            10
+        ]
+    },
+    "16": {
+        "className": "operator",
+        "level": [
+            10,
+            11,
+            12,
+            14,
+            22
+        ],
+        "cooldown": 800,
+        "range": 3,
+        "duration": 1000,
+        "ops": 200,
+        "effect": [
+            1,
+            2,
+            3,
+            4,
+            5
+        ]
+    },
+    "17": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 5,
+        "range": 3,
+        "ops": 5,
+        "duration": [
+            1,
+            2,
+            3,
+            4,
+            5
+        ]
+    },
+    "18": {
+        "className": "operator",
+        "level": [
+            20,
+            21,
+            22,
+            23,
+            24
+        ],
+        "cooldown": 800,
+        "range": 3,
+        "duration": 1000,
+        "ops": 200,
+        "effect": [
+            10,
+            20,
+            30,
+            40,
+            50
+        ]
+    },
+    "19": {
+        "className": "operator",
+        "level": [
+            0,
+            2,
+            7,
+            14,
+            22
+        ],
+        "cooldown": 800,
+        "range": 3,
+        "duration": 1000,
+        "ops": 100
+    }
+};
 
-        },
-        [exports.PWR_FORTIFY]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 5,
-            range: 3,
-            ops: 5,
-            duration: [1, 2, 3, 4, 5]
-        },
-        [exports.PWR_OPERATE_POWER]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [10, 11, 12, 14, 22],
-            cooldown: 1000,
-            range: 3,
-            duration: 800,
-            ops: 200,
-            effect: [1, 2, 3, 4, 5]
-        },
-        [exports.PWR_OPERATE_CONTROLLER]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [20, 21, 22, 23, 24],
-            cooldown: 1000,
-            range: 3,
-            duration: 800,
-            ops: 200,
-            effect: [10, 20, 30, 40, 50]
-        },
-        [exports.PWR_OPERATE_FACTORY]: {
-            className: exports.POWER_CLASS.OPERATOR,
-            level: [0, 2, 7, 14, 22],
-            cooldown: 1000,
-            range: 3,
-            duration: 800,
-            ops: 100
-        },
-    };
+/**
+ * @constant
+ * @type {object}
+ */
+const BODYPARTS_ALL = [
+    "move",
+    "work",
+    "carry",
+    "attack",
+    "ranged_attack",
+    "tough",
+    "heal",
+    "claim"
+];
+
+/**
+ * @constant
+ * @type {object}
+ */
+const RESOURCES_ALL = [
+    "energy",
+    "power",
+    "H",
+    "O",
+    "U",
+    "K",
+    "L",
+    "Z",
+    "X",
+    "G",
+    "OH",
+    "ZK",
+    "UL",
+    "UH",
+    "UO",
+    "KH",
+    "KO",
+    "LH",
+    "LO",
+    "ZH",
+    "ZO",
+    "GH",
+    "GO",
+    "UH2O",
+    "UHO2",
+    "KH2O",
+    "KHO2",
+    "LH2O",
+    "LHO2",
+    "ZH2O",
+    "ZHO2",
+    "GH2O",
+    "GHO2",
+    "XUH2O",
+    "XUHO2",
+    "XKH2O",
+    "XKHO2",
+    "XLH2O",
+    "XLHO2",
+    "XZH2O",
+    "XZHO2",
+    "XGH2O",
+    "XGHO2",
+    "ops",
+    "silicon",
+    "metal",
+    "biomass",
+    "mist",
+    "utrium_bar",
+    "lemergium_bar",
+    "zynthium_bar",
+    "keanium_bar",
+    "ghodium_melt",
+    "oxidant",
+    "reductant",
+    "purifier",
+    "battery",
+    "composite",
+    "crystal",
+    "liquid",
+    "wire",
+    "switch",
+    "transistor",
+    "microchip",
+    "circuit",
+    "device",
+    "cell",
+    "phlegm",
+    "tissue",
+    "muscle",
+    "organoid",
+    "organism",
+    "alloy",
+    "tube",
+    "fixtures",
+    "frame",
+    "hydraulics",
+    "machine",
+    "condensate",
+    "concentrate",
+    "extract",
+    "spirit",
+    "emanation",
+    "essence"
+];
+
+/**
+ * @constant
+ * @type {object}
+ */
+const COLORS_ALL = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    6,
+    7,
+    8,
+    9,
+    10
+];
+
+/**
+ * @constant
+ * @type {object}
+ */
+const INTERSHARD_RESOURCES = [
+    "token"
+];
+
+/**
+ * @constant
+ * @type {object}
+ */
+const COMMODITIES = {
+    "utrium_bar": {
+        "amount": 100,
+        "cooldown": 20,
+        "components": {
+            "U": 500,
+            "energy": 200
+        }
+    },
+    "U": {
+        "amount": 500,
+        "cooldown": 20,
+        "components": {
+            "utrium_bar": 100,
+            "energy": 200
+        }
+    },
+    "lemergium_bar": {
+        "amount": 100,
+        "cooldown": 20,
+        "components": {
+            "L": 500,
+            "energy": 200
+        }
+    },
+    "L": {
+        "amount": 500,
+        "cooldown": 20,
+        "components": {
+            "lemergium_bar": 100,
+            "energy": 200
+        }
+    },
+    "zynthium_bar": {
+        "amount": 100,
+        "cooldown": 20,
+        "components": {
+            "Z": 500,
+            "energy": 200
+        }
+    },
+    "Z": {
+        "amount": 500,
+        "cooldown": 20,
+        "components": {
+            "zynthium_bar": 100,
+            "energy": 200
+        }
+    },
+    "keanium_bar": {
+        "amount": 100,
+        "cooldown": 20,
+        "components": {
+            "K": 500,
+            "energy": 200
+        }
+    },
+    "K": {
+        "amount": 500,
+        "cooldown": 20,
+        "components": {
+            "keanium_bar": 100,
+            "energy": 200
+        }
+    },
+    "ghodium_melt": {
+        "amount": 100,
+        "cooldown": 20,
+        "components": {
+            "G": 500,
+            "energy": 200
+        }
+    },
+    "G": {
+        "amount": 500,
+        "cooldown": 20,
+        "components": {
+            "ghodium_melt": 100,
+            "energy": 200
+        }
+    },
+    "oxidant": {
+        "amount": 100,
+        "cooldown": 20,
+        "components": {
+            "O": 500,
+            "energy": 200
+        }
+    },
+    "O": {
+        "amount": 500,
+        "cooldown": 20,
+        "components": {
+            "oxidant": 100,
+            "energy": 200
+        }
+    },
+    "reductant": {
+        "amount": 100,
+        "cooldown": 20,
+        "components": {
+            "H": 500,
+            "energy": 200
+        }
+    },
+    "H": {
+        "amount": 500,
+        "cooldown": 20,
+        "components": {
+            "reductant": 100,
+            "energy": 200
+        }
+    },
+    "purifier": {
+        "amount": 100,
+        "cooldown": 20,
+        "components": {
+            "X": 500,
+            "energy": 200
+        }
+    },
+    "X": {
+        "amount": 500,
+        "cooldown": 20,
+        "components": {
+            "purifier": 100,
+            "energy": 200
+        }
+    },
+    "battery": {
+        "amount": 50,
+        "cooldown": 10,
+        "components": {
+            "energy": 600
+        }
+    },
+    "energy": {
+        "amount": 500,
+        "cooldown": 10,
+        "components": {
+            "battery": 50
+        }
+    },
+    "composite": {
+        "level": 1,
+        "amount": 20,
+        "cooldown": 50,
+        "components": {
+            "utrium_bar": 20,
+            "zynthium_bar": 20,
+            "energy": 20
+        }
+    },
+    "crystal": {
+        "level": 2,
+        "amount": 6,
+        "cooldown": 21,
+        "components": {
+            "lemergium_bar": 6,
+            "keanium_bar": 6,
+            "purifier": 6,
+            "energy": 45
+        }
+    },
+    "liquid": {
+        "level": 3,
+        "amount": 12,
+        "cooldown": 60,
+        "components": {
+            "oxidant": 12,
+            "reductant": 12,
+            "ghodium_melt": 12,
+            "energy": 90
+        }
+    },
+    "wire": {
+        "amount": 20,
+        "cooldown": 8,
+        "components": {
+            "utrium_bar": 20,
+            "silicon": 100,
+            "energy": 40
+        }
+    },
+    "switch": {
+        "level": 1,
+        "amount": 5,
+        "cooldown": 70,
+        "components": {
+            "wire": 40,
+            "oxidant": 95,
+            "utrium_bar": 35,
+            "energy": 20
+        }
+    },
+    "transistor": {
+        "level": 2,
+        "amount": 1,
+        "cooldown": 59,
+        "components": {
+            "switch": 4,
+            "wire": 15,
+            "reductant": 85,
+            "energy": 8
+        }
+    },
+    "microchip": {
+        "level": 3,
+        "amount": 1,
+        "cooldown": 250,
+        "components": {
+            "transistor": 2,
+            "composite": 50,
+            "wire": 117,
+            "purifier": 25,
+            "energy": 16
+        }
+    },
+    "circuit": {
+        "level": 4,
+        "amount": 1,
+        "cooldown": 800,
+        "components": {
+            "microchip": 1,
+            "transistor": 5,
+            "switch": 4,
+            "oxidant": 115,
+            "energy": 32
+        }
+    },
+    "device": {
+        "level": 5,
+        "amount": 1,
+        "cooldown": 600,
+        "components": {
+            "circuit": 1,
+            "microchip": 3,
+            "crystal": 110,
+            "ghodium_melt": 150,
+            "energy": 64
+        }
+    },
+    "cell": {
+        "amount": 20,
+        "cooldown": 8,
+        "components": {
+            "lemergium_bar": 20,
+            "biomass": 100,
+            "energy": 40
+        }
+    },
+    "phlegm": {
+        "level": 1,
+        "amount": 2,
+        "cooldown": 35,
+        "components": {
+            "cell": 20,
+            "oxidant": 36,
+            "lemergium_bar": 16,
+            "energy": 8
+        }
+    },
+    "tissue": {
+        "level": 2,
+        "amount": 2,
+        "cooldown": 164,
+        "components": {
+            "phlegm": 10,
+            "cell": 10,
+            "reductant": 110,
+            "energy": 16
+        }
+    },
+    "muscle": {
+        "level": 3,
+        "amount": 1,
+        "cooldown": 250,
+        "components": {
+            "tissue": 3,
+            "phlegm": 3,
+            "zynthium_bar": 50,
+            "reductant": 50,
+            "energy": 16
+        }
+    },
+    "organoid": {
+        "level": 4,
+        "amount": 1,
+        "cooldown": 800,
+        "components": {
+            "muscle": 1,
+            "tissue": 5,
+            "purifier": 208,
+            "oxidant": 256,
+            "energy": 32
+        }
+    },
+    "organism": {
+        "level": 5,
+        "amount": 1,
+        "cooldown": 600,
+        "components": {
+            "organoid": 1,
+            "liquid": 150,
+            "tissue": 6,
+            "cell": 310,
+            "energy": 64
+        }
+    },
+    "alloy": {
+        "amount": 20,
+        "cooldown": 8,
+        "components": {
+            "zynthium_bar": 20,
+            "metal": 100,
+            "energy": 40
+        }
+    },
+    "tube": {
+        "level": 1,
+        "amount": 2,
+        "cooldown": 45,
+        "components": {
+            "alloy": 40,
+            "zynthium_bar": 16,
+            "energy": 8
+        }
+    },
+    "fixtures": {
+        "level": 2,
+        "amount": 1,
+        "cooldown": 115,
+        "components": {
+            "composite": 20,
+            "alloy": 41,
+            "oxidant": 161,
+            "energy": 8
+        }
+    },
+    "frame": {
+        "level": 3,
+        "amount": 1,
+        "cooldown": 125,
+        "components": {
+            "fixtures": 2,
+            "tube": 4,
+            "reductant": 330,
+            "zynthium_bar": 31,
+            "energy": 16
+        }
+    },
+    "hydraulics": {
+        "level": 4,
+        "amount": 1,
+        "cooldown": 800,
+        "components": {
+            "liquid": 150,
+            "fixtures": 3,
+            "tube": 15,
+            "purifier": 208,
+            "energy": 32
+        }
+    },
+    "machine": {
+        "level": 5,
+        "amount": 1,
+        "cooldown": 600,
+        "components": {
+            "hydraulics": 1,
+            "frame": 2,
+            "fixtures": 3,
+            "tube": 12,
+            "energy": 64
+        }
+    },
+    "condensate": {
+        "amount": 20,
+        "cooldown": 8,
+        "components": {
+            "keanium_bar": 20,
+            "mist": 100,
+            "energy": 40
+        }
+    },
+    "concentrate": {
+        "level": 1,
+        "amount": 3,
+        "cooldown": 41,
+        "components": {
+            "condensate": 30,
+            "keanium_bar": 15,
+            "reductant": 54,
+            "energy": 12
+        }
+    },
+    "extract": {
+        "level": 2,
+        "amount": 2,
+        "cooldown": 128,
+        "components": {
+            "concentrate": 10,
+            "condensate": 30,
+            "oxidant": 60,
+            "energy": 16
+        }
+    },
+    "spirit": {
+        "level": 3,
+        "amount": 1,
+        "cooldown": 200,
+        "components": {
+            "extract": 2,
+            "concentrate": 6,
+            "reductant": 90,
+            "purifier": 20,
+            "energy": 16
+        }
+    },
+    "emanation": {
+        "level": 4,
+        "amount": 1,
+        "cooldown": 800,
+        "components": {
+            "spirit": 2,
+            "extract": 2,
+            "concentrate": 3,
+            "keanium_bar": 112,
+            "energy": 32
+        }
+    },
+    "essence": {
+        "level": 5,
+        "amount": 1,
+        "cooldown": 600,
+        "components": {
+            "emanation": 1,
+            "spirit": 3,
+            "crystal": 110,
+            "ghodium_melt": 150,
+            "energy": 64
+        }
+    }
+};

--- a/Global/ConstantsModule.js
+++ b/Global/ConstantsModule.js
@@ -1,0 +1,1582 @@
+Object.assign(exports, {
+    OK: 0,
+    ERR_NOT_OWNER: -1,
+    ERR_NO_PATH: -2,
+    ERR_NAME_EXISTS: -3,
+    ERR_BUSY: -4,
+    ERR_NOT_FOUND: -5,
+    ERR_NOT_ENOUGH_ENERGY: -6,
+    ERR_NOT_ENOUGH_RESOURCES: -6,
+    ERR_INVALID_TARGET: -7,
+    ERR_FULL: -8,
+    ERR_NOT_IN_RANGE: -9,
+    ERR_INVALID_ARGS: -10,
+    ERR_TIRED: -11,
+    ERR_NO_BODYPART: -12,
+    ERR_NOT_ENOUGH_EXTENSIONS: -6,
+    ERR_RCL_NOT_ENOUGH: -14,
+    ERR_GCL_NOT_ENOUGH: -15,
+
+    FIND_EXIT_TOP: 1,
+    FIND_EXIT_RIGHT: 3,
+    FIND_EXIT_BOTTOM: 5,
+    FIND_EXIT_LEFT: 7,
+    FIND_EXIT: 10,
+    FIND_CREEPS: 101,
+    FIND_MY_CREEPS: 102,
+    FIND_HOSTILE_CREEPS: 103,
+    FIND_SOURCES_ACTIVE: 104,
+    FIND_SOURCES: 105,
+    FIND_DROPPED_RESOURCES: 106,
+    FIND_STRUCTURES: 107,
+    FIND_MY_STRUCTURES: 108,
+    FIND_HOSTILE_STRUCTURES: 109,
+    FIND_FLAGS: 110,
+    FIND_CONSTRUCTION_SITES: 111,
+    FIND_MY_SPAWNS: 112,
+    FIND_HOSTILE_SPAWNS: 113,
+    FIND_MY_CONSTRUCTION_SITES: 114,
+    FIND_HOSTILE_CONSTRUCTION_SITES: 115,
+    FIND_MINERALS: 116,
+    FIND_NUKES: 117,
+    FIND_TOMBSTONES: 118,
+    FIND_POWER_CREEPS: 119,
+    FIND_MY_POWER_CREEPS: 120,
+    FIND_HOSTILE_POWER_CREEPS: 121,
+    FIND_DEPOSITS: 122,
+    FIND_RUINS: 123,
+
+    TOP: 1,
+    TOP_RIGHT: 2,
+    RIGHT: 3,
+    BOTTOM_RIGHT: 4,
+    BOTTOM: 5,
+    BOTTOM_LEFT: 6,
+    LEFT: 7,
+    TOP_LEFT: 8,
+
+    COLOR_RED: 1,
+    COLOR_PURPLE: 2,
+    COLOR_BLUE: 3,
+    COLOR_CYAN: 4,
+    COLOR_GREEN: 5,
+    COLOR_YELLOW: 6,
+    COLOR_ORANGE: 7,
+    COLOR_BROWN: 8,
+    COLOR_GREY: 9,
+    COLOR_WHITE: 10,
+
+    LOOK_CREEPS: "creep",
+    LOOK_ENERGY: "energy",
+    LOOK_RESOURCES: "resource",
+    LOOK_SOURCES: "source",
+    LOOK_MINERALS: "mineral",
+    LOOK_DEPOSITS: "deposit",
+    LOOK_STRUCTURES: "structure",
+    LOOK_FLAGS: "flag",
+    LOOK_CONSTRUCTION_SITES: "constructionSite",
+    LOOK_NUKES: "nuke",
+    LOOK_TERRAIN: "terrain",
+    LOOK_TOMBSTONES: "tombstone",
+    LOOK_POWER_CREEPS: "powerCreep",
+    LOOK_RUINS: "ruin",
+
+    OBSTACLE_OBJECT_TYPES: ["spawn", "creep", "powerCreep", "source", "mineral", "deposit", "controller", "constructedWall", "extension", "link", "storage", "tower", "observer", "powerSpawn", "powerBank", "lab", "terminal", "nuker", "factory", "invaderCore"],
+
+    MOVE: "move",
+    WORK: "work",
+    CARRY: "carry",
+    ATTACK: "attack",
+    RANGED_ATTACK: "ranged_attack",
+    TOUGH: "tough",
+    HEAL: "heal",
+    CLAIM: "claim",
+
+    BODYPART_COST: {
+        "move": 50,
+        "work": 100,
+        "attack": 80,
+        "carry": 50,
+        "heal": 250,
+        "ranged_attack": 150,
+        "tough": 10,
+        "claim": 600
+    },
+
+    // WORLD_WIDTH and WORLD_HEIGHT constants are deprecated, please use Game.map.getWorldSize() instead
+    WORLD_WIDTH: 202,
+    WORLD_HEIGHT: 202,
+
+    CREEP_LIFE_TIME: 1500,
+    CREEP_CLAIM_LIFE_TIME: 600,
+    CREEP_CORPSE_RATE: 0.2,
+    CREEP_PART_MAX_ENERGY: 125,
+
+    CARRY_CAPACITY: 50,
+    HARVEST_POWER: 2,
+    HARVEST_MINERAL_POWER: 1,
+    HARVEST_DEPOSIT_POWER: 1,
+    REPAIR_POWER: 100,
+    DISMANTLE_POWER: 50,
+    BUILD_POWER: 5,
+    ATTACK_POWER: 30,
+    UPGRADE_CONTROLLER_POWER: 1,
+    RANGED_ATTACK_POWER: 10,
+    HEAL_POWER: 12,
+    RANGED_HEAL_POWER: 4,
+    REPAIR_COST: 0.01,
+    DISMANTLE_COST: 0.005,
+
+    RAMPART_DECAY_AMOUNT: 300,
+    RAMPART_DECAY_TIME: 100,
+    RAMPART_HITS: 1,
+    RAMPART_HITS_MAX: {2: 300000, 3: 1000000, 4: 3000000, 5: 10000000, 6: 30000000, 7: 100000000, 8: 300000000},
+
+    ENERGY_REGEN_TIME: 300,
+    ENERGY_DECAY: 1000,
+
+    SPAWN_HITS: 5000,
+    SPAWN_ENERGY_START: 300,
+    SPAWN_ENERGY_CAPACITY: 300,
+    CREEP_SPAWN_TIME: 3,
+    SPAWN_RENEW_RATIO: 1.2,
+
+    SOURCE_ENERGY_CAPACITY: 3000,
+    SOURCE_ENERGY_NEUTRAL_CAPACITY: 1500,
+    SOURCE_ENERGY_KEEPER_CAPACITY: 4000,
+
+    WALL_HITS: 1,
+    WALL_HITS_MAX: 300000000,
+
+    EXTENSION_HITS: 1000,
+    EXTENSION_ENERGY_CAPACITY: {0: 50, 1: 50, 2: 50, 3: 50, 4: 50, 5: 50, 6: 50, 7: 100, 8: 200},
+
+    ROAD_HITS: 5000,
+    ROAD_WEAROUT: 1,
+    ROAD_WEAROUT_POWER_CREEP: 100,
+    ROAD_DECAY_AMOUNT: 100,
+    ROAD_DECAY_TIME: 1000,
+
+    LINK_HITS: 1000,
+    LINK_HITS_MAX: 1000,
+    LINK_CAPACITY: 800,
+    LINK_COOLDOWN: 1,
+    LINK_LOSS_RATIO: 0.03,
+
+    STORAGE_CAPACITY: 1000000,
+    STORAGE_HITS: 10000,
+
+    STRUCTURE_SPAWN: "spawn",
+    STRUCTURE_EXTENSION: "extension",
+    STRUCTURE_ROAD: "road",
+    STRUCTURE_WALL: "constructedWall",
+    STRUCTURE_RAMPART: "rampart",
+    STRUCTURE_KEEPER_LAIR: "keeperLair",
+    STRUCTURE_PORTAL: "portal",
+    STRUCTURE_CONTROLLER: "controller",
+    STRUCTURE_LINK: "link",
+    STRUCTURE_STORAGE: "storage",
+    STRUCTURE_TOWER: "tower",
+    STRUCTURE_OBSERVER: "observer",
+    STRUCTURE_POWER_BANK: "powerBank",
+    STRUCTURE_POWER_SPAWN: "powerSpawn",
+    STRUCTURE_EXTRACTOR: "extractor",
+    STRUCTURE_LAB: "lab",
+    STRUCTURE_TERMINAL: "terminal",
+    STRUCTURE_CONTAINER: "container",
+    STRUCTURE_NUKER: "nuker",
+    STRUCTURE_FACTORY: "factory",
+    STRUCTURE_INVADER_CORE: "invaderCore",
+
+    CONSTRUCTION_COST: {
+        "spawn": 15000,
+        "extension": 3000,
+        "road": 300,
+        "constructedWall": 1,
+        "rampart": 1,
+        "link": 5000,
+        "storage": 30000,
+        "tower": 5000,
+        "observer": 8000,
+        "powerSpawn": 100000,
+        "extractor": 5000,
+        "lab": 50000,
+        "terminal": 100000,
+        "container": 5000,
+        "nuker": 100000,
+        "factory": 100000
+    },
+    CONSTRUCTION_COST_ROAD_SWAMP_RATIO: 5,
+    CONSTRUCTION_COST_ROAD_WALL_RATIO: 150,
+
+    CONTROLLER_LEVELS: {1: 200, 2: 45000, 3: 135000, 4: 405000, 5: 1215000, 6: 3645000, 7: 10935000},
+    CONTROLLER_STRUCTURES: {
+        "spawn": {0: 0, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 2, 8: 3},
+        "extension": {0: 0, 1: 0, 2: 5, 3: 10, 4: 20, 5: 30, 6: 40, 7: 50, 8: 60},
+        "link": {1: 0, 2: 0, 3: 0, 4: 0, 5: 2, 6: 3, 7: 4, 8: 6},
+        "road": {0: 2500, 1: 2500, 2: 2500, 3: 2500, 4: 2500, 5: 2500, 6: 2500, 7: 2500, 8: 2500},
+        "constructedWall": {1: 0, 2: 2500, 3: 2500, 4: 2500, 5: 2500, 6: 2500, 7: 2500, 8: 2500},
+        "rampart": {1: 0, 2: 2500, 3: 2500, 4: 2500, 5: 2500, 6: 2500, 7: 2500, 8: 2500},
+        "storage": {1: 0, 2: 0, 3: 0, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1},
+        "tower": {1: 0, 2: 0, 3: 1, 4: 1, 5: 2, 6: 2, 7: 3, 8: 6},
+        "observer": {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 1},
+        "powerSpawn": {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 1},
+        "extractor": {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 1, 7: 1, 8: 1},
+        "terminal": {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 1, 7: 1, 8: 1},
+        "lab": {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 3, 7: 6, 8: 10},
+        "container": {0: 5, 1: 5, 2: 5, 3: 5, 4: 5, 5: 5, 6: 5, 7: 5, 8: 5},
+        "nuker": {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0, 8: 1},
+        "factory": {1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 1, 8: 1}
+    },
+    CONTROLLER_DOWNGRADE: {1: 20000, 2: 10000, 3: 20000, 4: 40000, 5: 80000, 6: 120000, 7: 150000, 8: 200000},
+    CONTROLLER_DOWNGRADE_RESTORE: 100,
+    CONTROLLER_DOWNGRADE_SAFEMODE_THRESHOLD: 5000,
+    CONTROLLER_CLAIM_DOWNGRADE: 300,
+    CONTROLLER_RESERVE: 1,
+    CONTROLLER_RESERVE_MAX: 5000,
+    CONTROLLER_MAX_UPGRADE_PER_TICK: 15,
+    CONTROLLER_ATTACK_BLOCKED_UPGRADE: 1000,
+    CONTROLLER_NUKE_BLOCKED_UPGRADE: 200,
+
+    SAFE_MODE_DURATION: 20000,
+    SAFE_MODE_COOLDOWN: 50000,
+    SAFE_MODE_COST: 1000,
+
+    TOWER_HITS: 3000,
+    TOWER_CAPACITY: 1000,
+    TOWER_ENERGY_COST: 10,
+    TOWER_POWER_ATTACK: 600,
+    TOWER_POWER_HEAL: 400,
+    TOWER_POWER_REPAIR: 800,
+    TOWER_OPTIMAL_RANGE: 5,
+    TOWER_FALLOFF_RANGE: 20,
+    TOWER_FALLOFF: 0.75,
+
+    OBSERVER_HITS: 500,
+    OBSERVER_RANGE: 10,
+
+    POWER_BANK_HITS: 2000000,
+    POWER_BANK_CAPACITY_MAX: 5000,
+    POWER_BANK_CAPACITY_MIN: 500,
+    POWER_BANK_CAPACITY_CRIT: 0.3,
+    POWER_BANK_DECAY: 5000,
+    POWER_BANK_HIT_BACK: 0.5,
+
+    POWER_SPAWN_HITS: 5000,
+    POWER_SPAWN_ENERGY_CAPACITY: 5000,
+    POWER_SPAWN_POWER_CAPACITY: 100,
+    POWER_SPAWN_ENERGY_RATIO: 50,
+
+    EXTRACTOR_HITS: 500,
+    EXTRACTOR_COOLDOWN: 5,
+
+    LAB_HITS: 500,
+    LAB_MINERAL_CAPACITY: 3000,
+    LAB_ENERGY_CAPACITY: 2000,
+    LAB_BOOST_ENERGY: 20,
+    LAB_BOOST_MINERAL: 30,
+    LAB_COOLDOWN: 10,           // not used
+    LAB_REACTION_AMOUNT: 5,
+    LAB_UNBOOST_ENERGY: 0,
+    LAB_UNBOOST_MINERAL: 15,
+
+    GCL_POW: 2.4,
+    GCL_MULTIPLY: 1000000,
+    GCL_NOVICE: 3,
+
+    MODE_SIMULATION: null,
+    MODE_WORLD: null,
+
+    TERRAIN_MASK_WALL: 1,
+    TERRAIN_MASK_SWAMP: 2,
+    TERRAIN_MASK_LAVA: 4,
+
+    MAX_CONSTRUCTION_SITES: 100,
+    MAX_CREEP_SIZE: 50,
+
+    MINERAL_REGEN_TIME: 50000,
+    MINERAL_MIN_AMOUNT: {
+        "H": 35000,
+        "O": 35000,
+        "L": 35000,
+        "K": 35000,
+        "Z": 35000,
+        "U": 35000,
+        "X": 35000
+    },
+    MINERAL_RANDOM_FACTOR: 2,
+
+    MINERAL_DENSITY: {
+        1: 15000,
+        2: 35000,
+        3: 70000,
+        4: 100000
+    },
+    MINERAL_DENSITY_PROBABILITY  : {
+        1: 0.1,
+        2: 0.5,
+        3: 0.9,
+        4: 1.0
+    },
+    MINERAL_DENSITY_CHANGE: 0.05,
+
+    DENSITY_LOW: 1,
+    DENSITY_MODERATE: 2,
+    DENSITY_HIGH: 3,
+    DENSITY_ULTRA: 4,
+
+    DEPOSIT_EXHAUST_MULTIPLY: 0.001,
+    DEPOSIT_EXHAUST_POW: 1.2,
+    DEPOSIT_DECAY_TIME: 50000,
+
+    TERMINAL_CAPACITY: 300000,
+    TERMINAL_HITS: 3000,
+    TERMINAL_SEND_COST: 0.1,
+    TERMINAL_MIN_SEND: 100,
+    TERMINAL_COOLDOWN: 10,
+
+    CONTAINER_HITS: 250000,
+    CONTAINER_CAPACITY: 2000,
+    CONTAINER_DECAY: 5000,
+    CONTAINER_DECAY_TIME: 100,
+    CONTAINER_DECAY_TIME_OWNED: 500,
+
+    NUKER_HITS: 1000,
+    NUKER_COOLDOWN: 100000,
+    NUKER_ENERGY_CAPACITY: 300000,
+    NUKER_GHODIUM_CAPACITY: 5000,
+    NUKE_LAND_TIME: 50000,
+    NUKE_RANGE: 10,
+    NUKE_DAMAGE: {
+        0: 10000000,
+        2: 5000000
+    },
+
+    FACTORY_HITS: 1000,
+    FACTORY_CAPACITY: 50000,
+
+    TOMBSTONE_DECAY_PER_PART: 5,
+    TOMBSTONE_DECAY_POWER_CREEP: 500,
+
+    RUIN_DECAY: 500,
+    RUIN_DECAY_STRUCTURES: {
+        'powerBank': 10
+    },
+
+    PORTAL_DECAY: 30000,
+
+    ORDER_SELL: "sell",
+    ORDER_BUY: "buy",
+
+    MARKET_FEE: 0.05,
+
+    MARKET_MAX_ORDERS: 300,
+    MARKET_ORDER_LIFE_TIME: 1000*60*60*24*30,
+
+    FLAGS_LIMIT: 10000,
+
+    SUBSCRIPTION_TOKEN: "token",
+
+    RESOURCE_ENERGY: "energy",
+    RESOURCE_POWER: "power",
+
+    RESOURCE_HYDROGEN: "H",
+    RESOURCE_OXYGEN: "O",
+    RESOURCE_UTRIUM: "U",
+    RESOURCE_LEMERGIUM: "L",
+    RESOURCE_KEANIUM: "K",
+    RESOURCE_ZYNTHIUM: "Z",
+    RESOURCE_CATALYST: "X",
+    RESOURCE_GHODIUM: "G",
+
+    RESOURCE_SILICON: 'silicon',
+    RESOURCE_METAL: 'metal',
+    RESOURCE_BIOMASS: 'biomass',
+    RESOURCE_MIST: 'mist',
+
+    RESOURCE_HYDROXIDE: "OH",
+    RESOURCE_ZYNTHIUM_KEANITE: "ZK",
+    RESOURCE_UTRIUM_LEMERGITE: "UL",
+
+    RESOURCE_UTRIUM_HYDRIDE: "UH",
+    RESOURCE_UTRIUM_OXIDE: "UO",
+    RESOURCE_KEANIUM_HYDRIDE: "KH",
+    RESOURCE_KEANIUM_OXIDE: "KO",
+    RESOURCE_LEMERGIUM_HYDRIDE: "LH",
+    RESOURCE_LEMERGIUM_OXIDE: "LO",
+    RESOURCE_ZYNTHIUM_HYDRIDE: "ZH",
+    RESOURCE_ZYNTHIUM_OXIDE: "ZO",
+    RESOURCE_GHODIUM_HYDRIDE: "GH",
+    RESOURCE_GHODIUM_OXIDE: "GO",
+
+    RESOURCE_UTRIUM_ACID: "UH2O",
+    RESOURCE_UTRIUM_ALKALIDE: "UHO2",
+    RESOURCE_KEANIUM_ACID: "KH2O",
+    RESOURCE_KEANIUM_ALKALIDE: "KHO2",
+    RESOURCE_LEMERGIUM_ACID: "LH2O",
+    RESOURCE_LEMERGIUM_ALKALIDE: "LHO2",
+    RESOURCE_ZYNTHIUM_ACID: "ZH2O",
+    RESOURCE_ZYNTHIUM_ALKALIDE: "ZHO2",
+    RESOURCE_GHODIUM_ACID: "GH2O",
+    RESOURCE_GHODIUM_ALKALIDE: "GHO2",
+
+    RESOURCE_CATALYZED_UTRIUM_ACID: "XUH2O",
+    RESOURCE_CATALYZED_UTRIUM_ALKALIDE: "XUHO2",
+    RESOURCE_CATALYZED_KEANIUM_ACID: "XKH2O",
+    RESOURCE_CATALYZED_KEANIUM_ALKALIDE: "XKHO2",
+    RESOURCE_CATALYZED_LEMERGIUM_ACID: "XLH2O",
+    RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE: "XLHO2",
+    RESOURCE_CATALYZED_ZYNTHIUM_ACID: "XZH2O",
+    RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE: "XZHO2",
+    RESOURCE_CATALYZED_GHODIUM_ACID: "XGH2O",
+    RESOURCE_CATALYZED_GHODIUM_ALKALIDE: "XGHO2",
+
+    RESOURCE_OPS: "ops",
+
+    RESOURCE_UTRIUM_BAR: 'utrium_bar',
+    RESOURCE_LEMERGIUM_BAR: 'lemergium_bar',
+    RESOURCE_ZYNTHIUM_BAR: 'zynthium_bar',
+    RESOURCE_KEANIUM_BAR: 'keanium_bar',
+    RESOURCE_GHODIUM_MELT: 'ghodium_melt',
+    RESOURCE_OXIDANT: 'oxidant',
+    RESOURCE_REDUCTANT: 'reductant',
+    RESOURCE_PURIFIER: 'purifier',
+    RESOURCE_BATTERY: 'battery',
+
+    RESOURCE_COMPOSITE: 'composite',
+    RESOURCE_CRYSTAL: 'crystal',
+    RESOURCE_LIQUID: 'liquid',
+
+    RESOURCE_WIRE: 'wire',
+    RESOURCE_SWITCH: 'switch',
+    RESOURCE_TRANSISTOR: 'transistor',
+    RESOURCE_MICROCHIP: 'microchip',
+    RESOURCE_CIRCUIT: 'circuit',
+    RESOURCE_DEVICE: 'device',
+
+    RESOURCE_CELL: 'cell',
+    RESOURCE_PHLEGM: 'phlegm',
+    RESOURCE_TISSUE: 'tissue',
+    RESOURCE_MUSCLE: 'muscle',
+    RESOURCE_ORGANOID: 'organoid',
+    RESOURCE_ORGANISM: 'organism',
+
+    RESOURCE_ALLOY: 'alloy',
+    RESOURCE_TUBE: 'tube',
+    RESOURCE_FIXTURES: 'fixtures',
+    RESOURCE_FRAME: 'frame',
+    RESOURCE_HYDRAULICS: 'hydraulics',
+    RESOURCE_MACHINE: 'machine',
+
+    RESOURCE_CONDENSATE: 'condensate',
+    RESOURCE_CONCENTRATE: 'concentrate',
+    RESOURCE_EXTRACT: 'extract',
+    RESOURCE_SPIRIT: 'spirit',
+    RESOURCE_EMANATION: 'emanation',
+    RESOURCE_ESSENCE: 'essence',
+
+    REACTIONS: {
+        H: {
+            O: "OH",
+            L: "LH",
+            K: "KH",
+            U: "UH",
+            Z: "ZH",
+            G: "GH"
+        },
+        O: {
+            H: "OH",
+            L: "LO",
+            K: "KO",
+            U: "UO",
+            Z: "ZO",
+            G: "GO"
+        },
+        Z: {
+            K: "ZK",
+            H: "ZH",
+            O: "ZO"
+        },
+        L: {
+            U: "UL",
+            H: "LH",
+            O: "LO"
+        },
+        K: {
+            Z: "ZK",
+            H: "KH",
+            O: "KO"
+        },
+        G: {
+            H: "GH",
+            O: "GO"
+        },
+        U: {
+            L: "UL",
+            H: "UH",
+            O: "UO"
+        },
+        OH: {
+            UH: "UH2O",
+            UO: "UHO2",
+            ZH: "ZH2O",
+            ZO: "ZHO2",
+            KH: "KH2O",
+            KO: "KHO2",
+            LH: "LH2O",
+            LO: "LHO2",
+            GH: "GH2O",
+            GO: "GHO2"
+        },
+        X: {
+            UH2O: "XUH2O",
+            UHO2: "XUHO2",
+            LH2O: "XLH2O",
+            LHO2: "XLHO2",
+            KH2O: "XKH2O",
+            KHO2: "XKHO2",
+            ZH2O: "XZH2O",
+            ZHO2: "XZHO2",
+            GH2O: "XGH2O",
+            GHO2: "XGHO2"
+        },
+        ZK: {
+            UL: "G"
+        },
+        UL: {
+            ZK: "G"
+        },
+        LH: {
+            OH: "LH2O"
+        },
+        ZH: {
+            OH: "ZH2O"
+        },
+        GH: {
+            OH: "GH2O"
+        },
+        KH: {
+            OH: "KH2O"
+        },
+        UH: {
+            OH: "UH2O"
+        },
+        LO: {
+            OH: "LHO2"
+        },
+        ZO: {
+            OH: "ZHO2"
+        },
+        KO: {
+            OH: "KHO2"
+        },
+        UO: {
+            OH: "UHO2"
+        },
+        GO: {
+            OH: "GHO2"
+        },
+        LH2O: {
+            X: "XLH2O"
+        },
+        KH2O: {
+            X: "XKH2O"
+        },
+        ZH2O: {
+            X: "XZH2O"
+        },
+        UH2O: {
+            X: "XUH2O"
+        },
+        GH2O: {
+            X: "XGH2O"
+        },
+        LHO2: {
+            X: "XLHO2"
+        },
+        UHO2: {
+            X: "XUHO2"
+        },
+        KHO2: {
+            X: "XKHO2"
+        },
+        ZHO2: {
+            X: "XZHO2"
+        },
+        GHO2: {
+            X: "XGHO2"
+        }
+    },
+
+    BOOSTS: {
+        work: {
+            UO: {
+                harvest: 3
+            },
+            UHO2: {
+                harvest: 5
+            },
+            XUHO2: {
+                harvest: 7
+            },
+            LH: {
+                build: 1.5,
+                repair: 1.5
+            },
+            LH2O: {
+                build: 1.8,
+                repair: 1.8
+            },
+            XLH2O: {
+                build: 2,
+                repair: 2
+            },
+            ZH: {
+                dismantle: 2
+            },
+            ZH2O: {
+                dismantle: 3
+            },
+            XZH2O: {
+                dismantle: 4
+            },
+            GH: {
+                upgradeController: 1.5
+            },
+            GH2O: {
+                upgradeController: 1.8
+            },
+            XGH2O: {
+                upgradeController: 2
+            }
+        },
+        attack: {
+            UH: {
+                attack: 2
+            },
+            UH2O: {
+                attack: 3
+            },
+            XUH2O: {
+                attack: 4
+            }
+        },
+        ranged_attack: {
+            KO: {
+                rangedAttack: 2,
+                rangedMassAttack: 2
+            },
+            KHO2: {
+                rangedAttack: 3,
+                rangedMassAttack: 3
+            },
+            XKHO2: {
+                rangedAttack: 4,
+                rangedMassAttack: 4
+            }
+        },
+        heal: {
+            LO: {
+                heal: 2,
+                rangedHeal: 2
+            },
+            LHO2: {
+                heal: 3,
+                rangedHeal: 3
+            },
+            XLHO2: {
+                heal: 4,
+                rangedHeal: 4
+            }
+        },
+        carry: {
+            KH: {
+                capacity: 2
+            },
+            KH2O: {
+                capacity: 3
+            },
+            XKH2O: {
+                capacity: 4
+            }
+        },
+        move: {
+            ZO: {
+                fatigue: 2
+            },
+            ZHO2: {
+                fatigue: 3
+            },
+            XZHO2: {
+                fatigue: 4
+            }
+        },
+        tough: {
+            GO: {
+                damage: .7
+            },
+            GHO2: {
+                damage: .5
+            },
+            XGHO2: {
+                damage: .3
+            }
+        }
+    },
+
+    REACTION_TIME: {
+        OH: 20,
+        ZK: 5,
+        UL: 5,
+        G: 5,
+        UH: 10,
+        UH2O: 5,
+        XUH2O: 60,
+        UO: 10,
+        UHO2: 5,
+        XUHO2: 60,
+        KH: 10,
+        KH2O: 5,
+        XKH2O: 60,
+        KO: 10,
+        KHO2: 5,
+        XKHO2: 60,
+        LH: 15,
+        LH2O: 10,
+        XLH2O: 65,
+        LO: 10,
+        LHO2: 5,
+        XLHO2: 60,
+        ZH: 20,
+        ZH2O: 40,
+        XZH2O: 160,
+        ZO: 10,
+        ZHO2: 5,
+        XZHO2: 60,
+        GH: 10,
+        GH2O: 15,
+        XGH2O: 80,
+        GO: 10,
+        GHO2: 30,
+        XGHO2: 150,
+    },
+
+    PORTAL_UNSTABLE: 10*24*3600*1000,
+    PORTAL_MIN_TIMEOUT: 12*24*3600*1000,
+    PORTAL_MAX_TIMEOUT: 22*24*3600*1000,
+
+    POWER_BANK_RESPAWN_TIME: 50000,
+
+    INVADERS_ENERGY_GOAL: 100000,
+
+    SYSTEM_USERNAME: 'Screeps',
+
+    // SIGN_NOVICE_AREA and SIGN_RESPAWN_AREA constants are deprecated, please use SIGN_PLANNED_AREA instead
+    SIGN_NOVICE_AREA: 'A new Novice or Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.',
+    SIGN_RESPAWN_AREA: 'A new Novice or Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.',
+    SIGN_PLANNED_AREA: 'A new Novice or Respawn Area is being planned somewhere in this sector. Please make sure all important rooms are reserved.',
+
+    EVENT_ATTACK: 1,
+    EVENT_OBJECT_DESTROYED: 2,
+    EVENT_ATTACK_CONTROLLER: 3,
+    EVENT_BUILD: 4,
+    EVENT_HARVEST: 5,
+    EVENT_HEAL: 6,
+    EVENT_REPAIR: 7,
+    EVENT_RESERVE_CONTROLLER: 8,
+    EVENT_UPGRADE_CONTROLLER: 9,
+    EVENT_EXIT: 10,
+    EVENT_POWER: 11,
+    EVENT_TRANSFER: 12,
+
+    EVENT_ATTACK_TYPE_MELEE: 1,
+    EVENT_ATTACK_TYPE_RANGED: 2,
+    EVENT_ATTACK_TYPE_RANGED_MASS: 3,
+    EVENT_ATTACK_TYPE_DISMANTLE: 4,
+    EVENT_ATTACK_TYPE_HIT_BACK: 5,
+    EVENT_ATTACK_TYPE_NUKE: 6,
+
+    EVENT_HEAL_TYPE_MELEE: 1,
+    EVENT_HEAL_TYPE_RANGED: 2,
+
+    POWER_LEVEL_MULTIPLY: 1000,
+    POWER_LEVEL_POW: 2,
+    POWER_CREEP_SPAWN_COOLDOWN: 8*3600*1000,
+    POWER_CREEP_DELETE_COOLDOWN: 24*3600*1000,
+    POWER_CREEP_MAX_LEVEL: 25,
+    POWER_CREEP_LIFE_TIME: 5000,
+
+    POWER_CLASS: {
+        OPERATOR: 'operator'
+    },
+
+    PWR_GENERATE_OPS: 1,
+    PWR_OPERATE_SPAWN: 2,
+    PWR_OPERATE_TOWER: 3,
+    PWR_OPERATE_STORAGE: 4,
+    PWR_OPERATE_LAB: 5,
+    PWR_OPERATE_EXTENSION: 6,
+    PWR_OPERATE_OBSERVER: 7,
+    PWR_OPERATE_TERMINAL: 8,
+    PWR_DISRUPT_SPAWN: 9,
+    PWR_DISRUPT_TOWER: 10,
+    PWR_DISRUPT_SOURCE: 11,
+    PWR_SHIELD: 12,
+    PWR_REGEN_SOURCE: 13,
+    PWR_REGEN_MINERAL: 14,
+    PWR_DISRUPT_TERMINAL: 15,
+    PWR_OPERATE_POWER: 16,
+    PWR_FORTIFY: 17,
+    PWR_OPERATE_CONTROLLER: 18,
+    PWR_OPERATE_FACTORY: 19,
+
+    EFFECT_INVULNERABILITY: 1001,
+    EFFECT_COLLAPSE_TIMER: 1002,
+
+    INVADER_CORE_HITS: 100000,
+    INVADER_CORE_CREEP_SPAWN_TIME: {
+        0: 0, 1: 0, 2: 6, 3: 3, 4: 2, 5: 1
+    },
+    INVADER_CORE_EXPAND_TIME: { 1: 4000, 2: 3500, 3: 3000, 4: 2500, 5: 2000 },
+    INVADER_CORE_CONTROLLER_POWER: 2,
+    INVADER_CORE_CONTROLLER_DOWNGRADE: 5000,
+    STRONGHOLD_RAMPART_HITS: { 0: 0, 1: 100000, 2: 200000, 3: 500000, 4: 1000000, 5: 2000000 },
+    STRONGHOLD_DECAY_TICKS: 75000
+});
+
+Object.assign(exports, {
+    POWER_INFO: {
+        [exports.PWR_GENERATE_OPS]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 50,
+            effect: [1, 2, 4, 6, 8]
+        },
+        [exports.PWR_OPERATE_SPAWN]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 300,
+            duration: 1000,
+            range: 3,
+            ops: 100,
+            effect: [0.9, 0.7, 0.5, 0.35, 0.2]
+        },
+        [exports.PWR_OPERATE_TOWER]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 10,
+            duration: 100,
+            range: 3,
+            ops: 10,
+            effect: [1.1, 1.2, 1.3, 1.4, 1.5]
+        },
+        [exports.PWR_OPERATE_STORAGE]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 800,
+            duration: 1000,
+            range: 3,
+            ops: 100,
+            effect: [500000,1000000,2000000,4000000,7000000]
+        },
+        [exports.PWR_OPERATE_LAB]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 50,
+            duration: 1000,
+            range: 3,
+            ops: 10,
+            effect: [2,4,6,8,10]
+        },
+        [exports.PWR_OPERATE_EXTENSION]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 50,
+            range: 3,
+            ops: 2,
+            effect: [0.2, 0.4, 0.6, 0.8, 1.0]
+        },
+        [exports.PWR_OPERATE_OBSERVER]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 400,
+            duration: [200,400,600,800,1000],
+            range: 3,
+            ops: 10,
+        },
+        [exports.PWR_OPERATE_TERMINAL]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 500,
+            duration: 1000,
+            range: 3,
+            ops: 100,
+            effect: [0.9, 0.8, 0.7, 0.6, 0.5]
+        },
+        [exports.PWR_DISRUPT_SPAWN]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 5,
+            range: 20,
+            ops: 10,
+            duration: [1,2,3,4,5]
+        },
+        [exports.PWR_DISRUPT_TOWER]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 0,
+            duration: 5,
+            range: 50,
+            ops: 10,
+            effect: [0.9, 0.8, 0.7, 0.6, 0.5],
+        },
+        [exports.PWR_DISRUPT_SOURCE]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 100,
+            range: 3,
+            ops: 100,
+            duration: [100, 200, 300, 400, 500]
+        },
+        [exports.PWR_SHIELD]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            effect: [5000, 10000, 15000, 20000, 25000],
+            duration: 50,
+            cooldown: 20,
+            energy: 100,
+        },
+        [exports.PWR_REGEN_SOURCE]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [10, 11, 12, 14, 22],
+            cooldown: 100,
+            duration: 300,
+            range: 3,
+            effect: [50,100,150,200,250],
+            period: 15
+        },
+        [exports.PWR_REGEN_MINERAL]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [10, 11, 12, 14, 22],
+            cooldown: 100,
+            duration: 100,
+            range: 3,
+            effect: [2,4,6,8,10],
+            period: 10
+        },
+        [exports.PWR_DISRUPT_TERMINAL]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [20, 21, 22, 23, 24],
+            cooldown: 8,
+            duration: 10,
+            range: 50,
+            ops: [50,40,30,20,10]
+
+        },
+        [exports.PWR_FORTIFY]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 5,
+            range: 3,
+            ops: 5,
+            duration: [1, 2, 3, 4, 5]
+        },
+        [exports.PWR_OPERATE_POWER]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [10, 11, 12, 14, 22],
+            cooldown: 800,
+            range: 3,
+            duration: 1000,
+            ops: 200,
+            effect: [1, 2, 3, 4, 5]
+        },
+        [exports.PWR_OPERATE_CONTROLLER]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [20, 21, 22, 23, 24],
+            cooldown: 800,
+            range: 3,
+            duration: 1000,
+            ops: 200,
+            effect: [10, 20, 30, 40, 50]
+        },
+        [exports.PWR_OPERATE_FACTORY]: {
+            className: exports.POWER_CLASS.OPERATOR,
+            level: [0, 2, 7, 14, 22],
+            cooldown: 800,
+            range: 3,
+            duration: 1000,
+            ops: 100
+        },
+    },
+
+    BODYPARTS_ALL: [
+        exports.MOVE,
+        exports.WORK,
+        exports.CARRY,
+        exports.ATTACK,
+        exports.RANGED_ATTACK,
+        exports.TOUGH,
+        exports.HEAL,
+        exports.CLAIM
+    ],
+    RESOURCES_ALL: [
+        exports.RESOURCE_ENERGY,
+        exports.RESOURCE_POWER,
+
+        exports.RESOURCE_HYDROGEN,
+        exports.RESOURCE_OXYGEN,
+        exports.RESOURCE_UTRIUM,
+        exports.RESOURCE_KEANIUM,
+        exports.RESOURCE_LEMERGIUM,
+        exports.RESOURCE_ZYNTHIUM,
+        exports.RESOURCE_CATALYST,
+        exports.RESOURCE_GHODIUM,
+
+        exports.RESOURCE_HYDROXIDE,
+        exports.RESOURCE_ZYNTHIUM_KEANITE,
+        exports.RESOURCE_UTRIUM_LEMERGITE,
+
+        exports.RESOURCE_UTRIUM_HYDRIDE,
+        exports.RESOURCE_UTRIUM_OXIDE,
+        exports.RESOURCE_KEANIUM_HYDRIDE,
+        exports.RESOURCE_KEANIUM_OXIDE,
+        exports.RESOURCE_LEMERGIUM_HYDRIDE,
+        exports.RESOURCE_LEMERGIUM_OXIDE,
+        exports.RESOURCE_ZYNTHIUM_HYDRIDE,
+        exports.RESOURCE_ZYNTHIUM_OXIDE,
+        exports.RESOURCE_GHODIUM_HYDRIDE,
+        exports.RESOURCE_GHODIUM_OXIDE,
+
+        exports.RESOURCE_UTRIUM_ACID,
+        exports.RESOURCE_UTRIUM_ALKALIDE,
+        exports.RESOURCE_KEANIUM_ACID,
+        exports.RESOURCE_KEANIUM_ALKALIDE,
+        exports.RESOURCE_LEMERGIUM_ACID,
+        exports.RESOURCE_LEMERGIUM_ALKALIDE,
+        exports.RESOURCE_ZYNTHIUM_ACID,
+        exports.RESOURCE_ZYNTHIUM_ALKALIDE,
+        exports.RESOURCE_GHODIUM_ACID,
+        exports.RESOURCE_GHODIUM_ALKALIDE,
+
+        exports.RESOURCE_CATALYZED_UTRIUM_ACID,
+        exports.RESOURCE_CATALYZED_UTRIUM_ALKALIDE,
+        exports.RESOURCE_CATALYZED_KEANIUM_ACID,
+        exports.RESOURCE_CATALYZED_KEANIUM_ALKALIDE,
+        exports.RESOURCE_CATALYZED_LEMERGIUM_ACID,
+        exports.RESOURCE_CATALYZED_LEMERGIUM_ALKALIDE,
+        exports.RESOURCE_CATALYZED_ZYNTHIUM_ACID,
+        exports.RESOURCE_CATALYZED_ZYNTHIUM_ALKALIDE,
+        exports.RESOURCE_CATALYZED_GHODIUM_ACID,
+        exports.RESOURCE_CATALYZED_GHODIUM_ALKALIDE,
+
+        exports.RESOURCE_OPS,
+
+        exports.RESOURCE_SILICON,
+        exports.RESOURCE_METAL,
+        exports.RESOURCE_BIOMASS,
+        exports.RESOURCE_MIST,
+
+        exports.RESOURCE_UTRIUM_BAR,
+        exports.RESOURCE_LEMERGIUM_BAR,
+        exports.RESOURCE_ZYNTHIUM_BAR,
+        exports.RESOURCE_KEANIUM_BAR,
+        exports.RESOURCE_GHODIUM_MELT,
+        exports.RESOURCE_OXIDANT,
+        exports.RESOURCE_REDUCTANT,
+        exports.RESOURCE_PURIFIER,
+        exports.RESOURCE_BATTERY,
+        exports.RESOURCE_COMPOSITE,
+        exports.RESOURCE_CRYSTAL,
+        exports.RESOURCE_LIQUID,
+
+        exports.RESOURCE_WIRE,
+        exports.RESOURCE_SWITCH,
+        exports.RESOURCE_TRANSISTOR,
+        exports.RESOURCE_MICROCHIP,
+        exports.RESOURCE_CIRCUIT,
+        exports.RESOURCE_DEVICE,
+
+        exports.RESOURCE_CELL,
+        exports.RESOURCE_PHLEGM,
+        exports.RESOURCE_TISSUE,
+        exports.RESOURCE_MUSCLE,
+        exports.RESOURCE_ORGANOID,
+        exports.RESOURCE_ORGANISM,
+
+        exports.RESOURCE_ALLOY,
+        exports.RESOURCE_TUBE,
+        exports.RESOURCE_FIXTURES,
+        exports.RESOURCE_FRAME,
+        exports.RESOURCE_HYDRAULICS,
+        exports.RESOURCE_MACHINE,
+
+        exports.RESOURCE_CONDENSATE,
+        exports.RESOURCE_CONCENTRATE,
+        exports.RESOURCE_EXTRACT,
+        exports.RESOURCE_SPIRIT,
+        exports.RESOURCE_EMANATION,
+        exports.RESOURCE_ESSENCE
+    ],
+    COLORS_ALL: [
+        exports.COLOR_RED,
+        exports.COLOR_PURPLE,
+        exports.COLOR_BLUE,
+        exports.COLOR_CYAN,
+        exports.COLOR_GREEN,
+        exports.COLOR_YELLOW,
+        exports.COLOR_ORANGE,
+        exports.COLOR_BROWN,
+        exports.COLOR_GREY,
+        exports.COLOR_WHITE
+    ],
+    INTERSHARD_RESOURCES: [
+        exports.SUBSCRIPTION_TOKEN
+    ],
+    COMMODITIES: {
+        [exports.RESOURCE_UTRIUM_BAR]: {
+            amount: 100,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_UTRIUM]: 500,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_UTRIUM]: {
+            amount: 500,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_UTRIUM_BAR]: 100,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_LEMERGIUM_BAR]: {
+            amount: 100,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_LEMERGIUM]: 500,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_LEMERGIUM]: {
+            amount: 500,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_LEMERGIUM_BAR]: 100,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_ZYNTHIUM_BAR]: {
+            amount: 100,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_ZYNTHIUM]: 500,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_ZYNTHIUM]: {
+            amount: 500,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_ZYNTHIUM_BAR]: 100,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_KEANIUM_BAR]: {
+            amount: 100,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_KEANIUM]: 500,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_KEANIUM]: {
+            amount: 500,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_KEANIUM_BAR]: 100,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_GHODIUM_MELT]: {
+            amount: 100,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_GHODIUM]: 500,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_GHODIUM]: {
+            amount: 500,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_GHODIUM_MELT]: 100,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_OXIDANT]: {
+            amount: 100,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_OXYGEN]: 500,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_OXYGEN]: {
+            amount: 500,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_OXIDANT]: 100,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_REDUCTANT]: {
+            amount: 100,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_HYDROGEN]: 500,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_HYDROGEN]: {
+            amount: 500,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_REDUCTANT]: 100,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_PURIFIER]: {
+            amount: 100,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_CATALYST]: 500,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_CATALYST]: {
+            amount: 500,
+            cooldown: 20,
+            components: {
+                [exports.RESOURCE_PURIFIER]: 100,
+                [exports.RESOURCE_ENERGY]: 200
+            }
+        },
+        [exports.RESOURCE_BATTERY]: {
+            amount: 50,
+            cooldown: 10,
+            components: {
+                [exports.RESOURCE_ENERGY]: 600
+            }
+        },
+        [exports.RESOURCE_ENERGY]: {
+            amount: 500,
+            cooldown: 10,
+            components: {
+                [exports.RESOURCE_BATTERY]: 50
+            }
+        },
+        [exports.RESOURCE_COMPOSITE]: {
+            level: 1,
+            amount: 20,
+            cooldown: 50,
+            components: {
+                [exports.RESOURCE_UTRIUM_BAR]: 20,
+                [exports.RESOURCE_ZYNTHIUM_BAR]: 20,
+                [exports.RESOURCE_ENERGY]: 20
+            }
+        },
+        [exports.RESOURCE_CRYSTAL]: {
+            level: 2,
+            amount: 6,
+            cooldown: 21,
+            components: {
+                [exports.RESOURCE_LEMERGIUM_BAR]: 6,
+                [exports.RESOURCE_KEANIUM_BAR]: 6,
+                [exports.RESOURCE_PURIFIER]: 6,
+                [exports.RESOURCE_ENERGY]: 45
+            }
+        },
+        [exports.RESOURCE_LIQUID]: {
+            level: 3,
+            amount: 12,
+            cooldown: 60,
+            components: {
+                [exports.RESOURCE_OXIDANT]: 12,
+                [exports.RESOURCE_REDUCTANT]: 12,
+                [exports.RESOURCE_GHODIUM_MELT]: 12,
+                [exports.RESOURCE_ENERGY]: 90
+            }
+        },
+
+        [exports.RESOURCE_WIRE]: {
+            amount: 20,
+            cooldown: 8,
+            components: {
+                [exports.RESOURCE_UTRIUM_BAR]: 20,
+                [exports.RESOURCE_SILICON]: 100,
+                [exports.RESOURCE_ENERGY]: 40
+            }
+        },
+        [exports.RESOURCE_SWITCH]: {
+            level: 1,
+            amount: 5,
+            cooldown: 70,
+            components: {
+                [exports.RESOURCE_WIRE]: 40,
+                [exports.RESOURCE_OXIDANT]: 95,
+                [exports.RESOURCE_UTRIUM_BAR]: 35,
+                [exports.RESOURCE_ENERGY]: 20
+            }
+        },
+        [exports.RESOURCE_TRANSISTOR]: {
+            level: 2,
+            amount: 1,
+            cooldown: 59,
+            components: {
+                [exports.RESOURCE_SWITCH]: 4,
+                [exports.RESOURCE_WIRE]: 15,
+                [exports.RESOURCE_REDUCTANT]: 85,
+                [exports.RESOURCE_ENERGY]: 8
+            }
+        },
+        [exports.RESOURCE_MICROCHIP]: {
+            level: 3,
+            amount: 1,
+            cooldown: 250,
+            components: {
+                [exports.RESOURCE_TRANSISTOR]: 2,
+                [exports.RESOURCE_COMPOSITE]: 50,
+                [exports.RESOURCE_WIRE]: 117,
+                [exports.RESOURCE_PURIFIER]: 25,
+                [exports.RESOURCE_ENERGY]: 16
+            }
+        },
+        [exports.RESOURCE_CIRCUIT]: {
+            level: 4,
+            amount: 1,
+            cooldown: 800,
+            components: {
+                [exports.RESOURCE_MICROCHIP]: 1,
+                [exports.RESOURCE_TRANSISTOR]: 5,
+                [exports.RESOURCE_SWITCH]: 4,
+                [exports.RESOURCE_OXIDANT]: 115,
+                [exports.RESOURCE_ENERGY]: 32
+            }
+        },
+        [exports.RESOURCE_DEVICE]: {
+            level: 5,
+            amount: 1,
+            cooldown: 600,
+            components: {
+                [exports.RESOURCE_CIRCUIT]: 1,
+                [exports.RESOURCE_MICROCHIP]: 3,
+                [exports.RESOURCE_CRYSTAL]: 110,
+                [exports.RESOURCE_GHODIUM_MELT]: 150,
+                [exports.RESOURCE_ENERGY]: 64
+            }
+        },
+
+        [exports.RESOURCE_CELL]: {
+            amount: 20,
+            cooldown: 8,
+            components: {
+                [exports.RESOURCE_LEMERGIUM_BAR]: 20,
+                [exports.RESOURCE_BIOMASS]: 100,
+                [exports.RESOURCE_ENERGY]: 40
+            }
+        },
+        [exports.RESOURCE_PHLEGM]: {
+            level: 1,
+            amount: 2,
+            cooldown: 35,
+            components: {
+                [exports.RESOURCE_CELL]: 20,
+                [exports.RESOURCE_OXIDANT]: 36,
+                [exports.RESOURCE_LEMERGIUM_BAR]: 16,
+                [exports.RESOURCE_ENERGY]: 8
+            }
+        },
+        [exports.RESOURCE_TISSUE]: {
+            level: 2,
+            amount: 2,
+            cooldown: 164,
+            components: {
+                [exports.RESOURCE_PHLEGM]: 10,
+                [exports.RESOURCE_CELL]: 10,
+                [exports.RESOURCE_REDUCTANT]: 110,
+                [exports.RESOURCE_ENERGY]: 16
+            }
+        },
+        [exports.RESOURCE_MUSCLE]: {
+            level: 3,
+            amount: 1,
+            cooldown: 250,
+            components: {
+                [exports.RESOURCE_TISSUE]: 3,
+                [exports.RESOURCE_PHLEGM]: 3,
+                [exports.RESOURCE_ZYNTHIUM_BAR]: 50,
+                [exports.RESOURCE_REDUCTANT]: 50,
+                [exports.RESOURCE_ENERGY]: 16
+            }
+        },
+        [exports.RESOURCE_ORGANOID]: {
+            level: 4,
+            amount: 1,
+            cooldown: 800,
+            components: {
+                [exports.RESOURCE_MUSCLE]: 1,
+                [exports.RESOURCE_TISSUE]: 5,
+                [exports.RESOURCE_PURIFIER]: 208,
+                [exports.RESOURCE_OXIDANT]: 256,
+                [exports.RESOURCE_ENERGY]: 32
+            }
+        },
+        [exports.RESOURCE_ORGANISM]: {
+            level: 5,
+            amount: 1,
+            cooldown: 600,
+            components: {
+                [exports.RESOURCE_ORGANOID]: 1,
+                [exports.RESOURCE_LIQUID]: 150,
+                [exports.RESOURCE_TISSUE]: 6,
+                [exports.RESOURCE_CELL]: 310,
+                [exports.RESOURCE_ENERGY]: 64
+            }
+        },
+
+        [exports.RESOURCE_ALLOY]: {
+            amount: 20,
+            cooldown: 8,
+            components: {
+                [exports.RESOURCE_ZYNTHIUM_BAR]: 20,
+                [exports.RESOURCE_METAL]: 100,
+                [exports.RESOURCE_ENERGY]: 40
+            }
+        },
+        [exports.RESOURCE_TUBE]: {
+            level: 1,
+            amount: 2,
+            cooldown: 45,
+            components: {
+                [exports.RESOURCE_ALLOY]: 40,
+                [exports.RESOURCE_ZYNTHIUM_BAR]: 16,
+                [exports.RESOURCE_ENERGY]: 8
+            }
+        },
+        [exports.RESOURCE_FIXTURES]: {
+            level: 2,
+            amount: 1,
+            cooldown: 115,
+            components: {
+                [exports.RESOURCE_COMPOSITE]: 20,
+                [exports.RESOURCE_ALLOY]: 41,
+                [exports.RESOURCE_OXIDANT]: 161,
+                [exports.RESOURCE_ENERGY]: 8
+            }
+        },
+        [exports.RESOURCE_FRAME]: {
+            level: 3,
+            amount: 1,
+            cooldown: 125,
+            components: {
+                [exports.RESOURCE_FIXTURES]: 2,
+                [exports.RESOURCE_TUBE]: 4,
+                [exports.RESOURCE_REDUCTANT]: 330,
+                [exports.RESOURCE_ZYNTHIUM_BAR]: 31,
+                [exports.RESOURCE_ENERGY]: 16
+            }
+        },
+        [exports.RESOURCE_HYDRAULICS]: {
+            level: 4,
+            amount: 1,
+            cooldown: 800,
+            components: {
+                [exports.RESOURCE_LIQUID]: 150,
+                [exports.RESOURCE_FIXTURES]: 3,
+                [exports.RESOURCE_TUBE]: 15,
+                [exports.RESOURCE_PURIFIER]: 208,
+                [exports.RESOURCE_ENERGY]: 32
+            }
+        },
+        [exports.RESOURCE_MACHINE]: {
+            level: 5,
+            amount: 1,
+            cooldown: 600,
+            components: {
+                [exports.RESOURCE_HYDRAULICS]: 1,
+                [exports.RESOURCE_FRAME]: 2,
+                [exports.RESOURCE_FIXTURES]: 3,
+                [exports.RESOURCE_TUBE]: 12,
+                [exports.RESOURCE_ENERGY]: 64
+            }
+        },
+
+        [exports.RESOURCE_CONDENSATE]: {
+            amount: 20,
+            cooldown: 8,
+            components: {
+                [exports.RESOURCE_KEANIUM_BAR]: 20,
+                [exports.RESOURCE_MIST]: 100,
+                [exports.RESOURCE_ENERGY]: 40
+            }
+        },
+        [exports.RESOURCE_CONCENTRATE]: {
+            level: 1,
+            amount: 3,
+            cooldown: 41,
+            components: {
+                [exports.RESOURCE_CONDENSATE]: 30,
+                [exports.RESOURCE_KEANIUM_BAR]: 15,
+                [exports.RESOURCE_REDUCTANT]: 54,
+                [exports.RESOURCE_ENERGY]: 12
+            }
+        },
+        [exports.RESOURCE_EXTRACT]: {
+            level: 2,
+            amount: 2,
+            cooldown: 128,
+            components: {
+                [exports.RESOURCE_CONCENTRATE]: 10,
+                [exports.RESOURCE_CONDENSATE]: 30,
+                [exports.RESOURCE_OXIDANT]: 60,
+                [exports.RESOURCE_ENERGY]: 16
+            }
+        },
+        [exports.RESOURCE_SPIRIT]: {
+            level: 3,
+            amount: 1,
+            cooldown: 200,
+            components: {
+                [exports.RESOURCE_EXTRACT]: 2,
+                [exports.RESOURCE_CONCENTRATE]: 6,
+                [exports.RESOURCE_REDUCTANT]: 90,
+                [exports.RESOURCE_PURIFIER]: 20,
+                [exports.RESOURCE_ENERGY]: 16
+            }
+        },
+        [exports.RESOURCE_EMANATION]: {
+            level: 4,
+            amount: 1,
+            cooldown: 800,
+            components: {
+                [exports.RESOURCE_SPIRIT]: 2,
+                [exports.RESOURCE_EXTRACT]: 2,
+                [exports.RESOURCE_CONCENTRATE]: 3,
+                [exports.RESOURCE_KEANIUM_BAR]: 112,
+                [exports.RESOURCE_ENERGY]: 32
+            }
+        },
+        [exports.RESOURCE_ESSENCE]: {
+            level: 5,
+            amount: 1,
+            cooldown: 600,
+            components: {
+                [exports.RESOURCE_EMANATION]: 1,
+                [exports.RESOURCE_SPIRIT]: 3,
+                [exports.RESOURCE_CRYSTAL]: 110,
+                [exports.RESOURCE_GHODIUM_MELT]: 150,
+                [exports.RESOURCE_ENERGY]: 64
+            }
+        },
+    }
+});

--- a/PathFinder.js
+++ b/PathFinder.js
@@ -31,6 +31,7 @@ PathFinder =
      * @param {boolean} [opts.flee] Instead of searching for a path to the goals this will search for a path away from the goals. The cheapest path that is out of range of every goal will be returned. The default is false.
      * @param {number} [opts.maxOps] The maximum allowed pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU. The default value is 2000.
      * @param {number} [opts.maxRooms] The maximum allowed rooms to search. The default is 16, maximum is 64.
+     * @param {number} [opts.maxCost] The maximum allowed cost of the path returned. If at any point the pathfinder detects that it is impossible to find a path with a cost less than or equal to maxCost it will immediately halt the search. The default is Infinity.
      * @param {number} [opts.heuristicWeight] Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand the underlying A* algorithm mechanics! The default value is 1.2.
      *
      * @return {{path:Array<RoomPosition>,opts:number,cost:number,incomplete:boolean}} An object containing: path - An array of RoomPosition objects; ops - Total number of operations performed before this path was calculated; cost - The total cost of the path as derived from plainCost, swampCost and any given CostMatrix instances; incomplete - If the pathfinder fails to find a complete path, this will be true. Note that path will still be populated with a partial path which represents the closest path it could find given the search parameters.

--- a/PowerCreep.js
+++ b/PowerCreep.js
@@ -294,7 +294,25 @@ PowerCreep.prototype =
      * @param {number} [opts.reusePath] This option enables reusing the path found along multiple game ticks. It allows to save CPU time, but can result in a slightly slower creep reaction behavior. The path is stored into the creep's memory to the _move property. The reusePath value defines the amount of ticks which the path should be reused for. The default value is 5. Increase the amount to save more CPU, decrease to make the movement more consistent. Set to 0 if you want to disable path reusing.
      * @param {boolean} [opts.serializeMemory] If reusePath is enabled and this option is set to true, the path will be stored in memory in the short serialized form using Room.serializePath. The default value is true.
      * @param {boolean} [opts.noPathFinding] If this option is set to true, moveTo method will return ERR_NOT_FOUND if there is no memorized path to reuse. This can significantly save CPU time in some cases. The default value is false.
-     * @note opts also supports any method from the Room.findPath options.
+     * @param {object} [opts.visualizePathStyle] Draw a line along the creep’s path using RoomVisual.poly. You can provide either an empty object or custom style parameters.
+     * @param {string} [opts.visualizePathStyle.fill] Fill color in any web format
+     * @param {string} [opts.visualizePathStyle.stroke] Stroke color in any web format
+     * @param {string} [opts.visualizePathStyle.lineStyle] Either undefined (solid line), dashed, or dotted
+     * @param {number} [opts.visualizePathStyle.strokeWidth] Stroke line width
+     * @param {number} [opts.visualizePathStyle.opacity] Opacity value
+     * @param {boolean} [opts.ignoreCreeps] Treat squares with creeps as walkable. Can be useful with too many moving creeps around or in some other cases. The default value is false.
+     * @param {boolean} [opts.ignoreDestructibleStructures] Treat squares with destructible structures (constructed walls, ramparts, spawns, extensions) as walkable. Use this flag when you need to move through a territory blocked by hostile structures. If a creep with an ATTACK body part steps on such a square, it automatically attacks the structure. The default value is false.
+     * @param {boolean} [opts.ignoreRoads] Ignore road structures. Enabling this option can speed up the search. The default value is false. This is only used when the new PathFinder is enabled.
+     * @param {function(string, CostMatrix)} [opts.costCallback] You can use this callback to modify a CostMatrix for any room during the search. The callback accepts two arguments, roomName and costMatrix. Use the costMatrix instance to make changes to the positions costs. If you return a new matrix from this callback, it will be used instead of the built-in cached one. This option is only used when the new PathFinder is enabled.
+     * @param {Array} [opts.ignore] An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     * @param {Array} [opts.avoid] An array of the room's objects or RoomPosition objects which should be treated as obstacles during the search. This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     * @param {number} [opts.maxOps] The maximum limit of possible pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU. The default value is 2000.
+     * @param {number} [opts.heuristicWeight] Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand the underlying A* algorithm mechanics! The default value is 1.2.
+     * @param {boolean} [opts.serialize] If true, the result path will be serialized using Room.serializePath. The default is false.
+     * @param {number} [opts.maxRooms] The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new PathFinder is enabled.
+     * @param {number} [opts.range] Find a path to a position in specified linear range of target. The default is 0.
+     * @param {number} [opts.plainCost] Cost for walking on plain positions. The default is 1.
+     * @param {number} [opts.swampCost] Cost for walking on swamp positions. The default is 5.
      *
      * @alias moveTo(target, [opts])
      *

--- a/PowerCreep.js
+++ b/PowerCreep.js
@@ -288,7 +288,7 @@ PowerCreep.prototype =
      *
      * @type {function}
      *
-     * @param {number} x X position of the target in the same room.
+     * @param {number|RoomPosition|RoomObject} x X position of the target in the same room.
      * @param {number} [y] Y position of the target in the same room.
      * @param {object} [opts] An object containing additional options
      * @param {number} [opts.reusePath] This option enables reusing the path found along multiple game ticks. It allows to save CPU time, but can result in a slightly slower creep reaction behavior. The path is stored into the creep's memory to the _move property. The reusePath value defines the amount of ticks which the path should be reused for. The default value is 5. Increase the amount to save more CPU, decrease to make the movement more consistent. Set to 0 if you want to disable path reusing.

--- a/PowerCreep.js
+++ b/PowerCreep.js
@@ -29,6 +29,8 @@ PowerCreep.prototype =
     create: function(name, className) { },
     
     /**
+     * @deprecated Since version 4.x, replaced by `.store`.
+     *
      * An object with the PowerCreep's cargo contents.
      * Each object key is one of the RESOURCE_* constants, values are resources amounts.
      * Use _.sum(creep.carry) to get the total amount of contents.
@@ -40,6 +42,8 @@ PowerCreep.prototype =
     carry: {},
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity()`.
+     *
      * The total amount of resources the PowerCreep can carry.
      *
      * @see {@link https://docs.screeps.com/api/#PowerCreep.carryCapacity}
@@ -154,6 +158,15 @@ PowerCreep.prototype =
     {
         username: ""
     },
+
+    /**
+     * A Store object that contains cargo of this creep.
+     *
+     * @see {@link https://docs.screeps.com/api/#PowerCreep.store}
+     *
+     * @type {Store}
+     */
+    store: {},
 
     /**
      * Available powers, an object with power ID as a key, and the following properties:

--- a/Room.js
+++ b/Room.js
@@ -204,6 +204,9 @@ Room.prototype =
      * @param {number} [opts.heuristicWeight] Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand the underlying A* algorithm mechanics! The default value is 1.2.
      * @param {boolean} [opts.serialize] If true, the result path will be serialized using Room.serializePath. The default is false.
      * @param {number} [opts.maxRooms] The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new PathFinder is enabled.
+     * @param {number} [opts.range] Find a path to a position in specified linear range of target. The default is 0.
+     * @param {number} [opts.plainCost] Cost for walking on plain positions. The default is 1.
+     * @param {number} [opts.swampCost] Cost for walking on swamp positions. The default is 5.
      *
      * @return {Array} An array with path steps in the following format:
                          [

--- a/RoomExt.js
+++ b/RoomExt.js
@@ -1,0 +1,236 @@
+Room.prototype = {
+  /**
+   * The Observer structure of this room, if present, otherwise undefined.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureObserver}
+   *
+   * @type {undefined|StructureObserver}
+   */
+   observer: undefined,
+
+  /**
+   * The PowerSpawn structure of this room, if present, otherwise undefined.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructurePowerSpawn}
+   *
+   * @type {undefined|StructurePowerSpawn}
+   */
+   powerSpawn: undefined,
+
+  /**
+   * The Extractor structure of this room, if present, otherwise undefined.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureExtractor}
+   *
+   * @type {undefined|StructureExtractor}
+   */
+   extractor: undefined,
+
+  /**
+   * The Nuker structure of this room, if present, otherwise undefined.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureNuker}
+   *
+   * @type {undefined|StructureNuker}
+   */
+   nuker: undefined,
+
+  /**
+   * The Factory structure of this room, if present, otherwise undefined.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureFactory}
+   *
+   * @type {undefined|StructureFactory}
+   */
+   factory: undefined,
+
+  /**
+   * The InvaderCore structure of this room, if present, otherwise undefined.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureInvaderCore}
+   *
+   * @type {undefined|StructureInvaderCore}
+   */
+   invaderCore: undefined,
+
+  /**
+   * The PowerBank structure of this room, if present, otherwise undefined.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructurePowerBank}
+   *
+   * @type {undefined|StructurePowerBank}
+   */
+   powerBank: undefined,
+
+  /**
+   * The Mineral of this room, if present, otherwise undefined.
+   *
+   * @see {@link https://docs.screeps.com/api/#Mineral}
+   *
+   * @type {undefined|Mineral}
+   */
+   mineral: undefined,
+
+  /**
+   * All Spawn structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureSpawn}
+   *
+   * @type {Array<StructureSpawn>}
+   */
+   spawns: [],
+
+  /**
+   * All Extension structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureExtension}
+   *
+   * @type {Array<StructureExtension>}
+   */
+   extensions: [],
+
+  /**
+   * All Road structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureRoad}
+   *
+   * @type {Array<StructureRoad>}
+   */
+   roads: [],
+
+  /**
+   * All ConstructedWall structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureConstructedWall}
+   *
+   * @type {Array<StructureConstructedWall>}
+   */
+   constructedWalls: [],
+
+  /**
+   * All Rampart structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureRampart}
+   *
+   * @type {Array<StructureRampart>}
+   */
+   ramparts: [],
+
+  /**
+   * All KeeperLair structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureKeeperLair}
+   *
+   * @type {Array<StructureKeeperLair>}
+   */
+   keeperLairs: [],
+
+  /**
+   * All Portal structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructurePortal}
+   *
+   * @type {Array<StructurePortal>}
+   */
+   portals: [],
+
+  /**
+   * All Link structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureLink}
+   *
+   * @type {Array<StructureLink>}
+   */
+   links: [],
+
+  /**
+   * All Tower structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureTower}
+   *
+   * @type {Array<StructureTower>}
+   */
+   towers: [],
+
+  /**
+   * All Lab structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureLab}
+   *
+   * @type {Array<StructureLab>}
+   */
+   labs: [],
+
+  /**
+   * All Container structures of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#StructureContainer}
+   *
+   * @type {Array<StructureContainer>}
+   */
+   containers: [],
+
+  /**
+   * All Source of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#Source}
+   *
+   * @type {Array<Source>}
+   */
+   sources: [],
+
+  /**
+   * All Deposit of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#Deposit}
+   *
+   * @type {Array<Deposit>}
+   */
+   deposits: [],
+
+  /**
+   * All Nuke of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#Nuke}
+   *
+   * @type {Array<Nuke>}
+   */
+   nukes: [],
+
+  /**
+   * All ConstructionSite of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#ConstructionSite}
+   *
+   * @type {Array<ConstructionSite>}
+   */
+   constructionSites: [],
+
+  /**
+   * All Tombstone of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#Tombstone}
+   *
+   * @type {Array<Tombstone>}
+   */
+   tombstones: [],
+
+  /**
+   * All Ruin of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#Ruin}
+   *
+   * @type {Array<Ruin>}
+   */
+   ruins: [],
+
+  /**
+   * All Resource of this room, if present, otherwise an empty array.
+   *
+   * @see {@link https://docs.screeps.com/api/#Resource}
+   *
+   * @type {Array<Resource>}
+   */
+   resources: [],
+
+}

--- a/RoomObject.js
+++ b/RoomObject.js
@@ -10,11 +10,11 @@ RoomObject = function() { };
 RoomObject.prototype =
 {
     /**
-     * Applied effects, an array of objects with the following properties:
+     * Applied effects, an array of objects
      *
      * @see {@link https://docs.screeps.com/api/#RoomObject.effects}
      *
-     * @type {array}
+     * @type {Array<{effect:number, level:number, ticksRemaining:number}>}
      */
     effects: null,
     /**

--- a/RoomPosition.js
+++ b/RoomPosition.js
@@ -86,6 +86,19 @@ RoomPosition.prototype =
                                         astar is faster when there are relatively few possible targets;
                                         dijkstra is faster when there are a lot of possible targets or when the closest target is nearby.
                                         The default value is determined automatically using heuristics.
+     * @param {boolean} [opts.ignoreCreeps] Treat squares with creeps as walkable. Can be useful with too many moving creeps around or in some other cases. The default value is false.
+     * @param {boolean} [opts.ignoreDestructibleStructures] Treat squares with destructible structures (constructed walls, ramparts, spawns, extensions) as walkable. Use this flag when you need to move through a territory blocked by hostile structures. If a creep with an ATTACK body part steps on such a square, it automatically attacks the structure. The default value is false.
+     * @param {boolean} [opts.ignoreRoads] Ignore road structures. Enabling this option can speed up the search. The default value is false. This is only used when the new PathFinder is enabled.
+     * @param {function(string, CostMatrix)} [opts.costCallback] You can use this callback to modify a CostMatrix for any room during the search. The callback accepts two arguments, roomName and costMatrix. Use the costMatrix instance to make changes to the positions costs. If you return a new matrix from this callback, it will be used instead of the built-in cached one. This option is only used when the new PathFinder is enabled.
+     * @param {Array} [opts.ignore] An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     * @param {Array} [opts.avoid] An array of the room's objects or RoomPosition objects which should be treated as obstacles during the search. This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     * @param {number} [opts.maxOps] The maximum limit of possible pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU. The default value is 2000.
+     * @param {number} [opts.heuristicWeight] Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand the underlying A* algorithm mechanics! The default value is 1.2.
+     * @param {boolean} [opts.serialize] If true, the result path will be serialized using Room.serializePath. The default is false.
+     * @param {number} [opts.maxRooms] The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new PathFinder is enabled.
+     * @param {number} [opts.range] Find a path to a position in specified linear range of target. The default is 0.
+     * @param {number} [opts.plainCost] Cost for walking on plain positions. The default is 1.
+     * @param {number} [opts.swampCost] Cost for walking on swamp positions. The default is 5.
 
      * @note Alternative function: findClosestByPath: function(objects, opts)
      * @param {array} objects An array of room's objects or RoomPosition objects that the search should be executed against.
@@ -142,6 +155,19 @@ RoomPosition.prototype =
      * @param {number|RoomPosition|RoomObject} x X position in the room.
      * @param {number} [y] Y position in the room.
      * @param {object} [opts] An object containing pathfinding options flags (see Room.findPath for more details).
+     * @param {boolean} [opts.ignoreCreeps] Treat squares with creeps as walkable. Can be useful with too many moving creeps around or in some other cases. The default value is false.
+     * @param {boolean} [opts.ignoreDestructibleStructures] Treat squares with destructible structures (constructed walls, ramparts, spawns, extensions) as walkable. Use this flag when you need to move through a territory blocked by hostile structures. If a creep with an ATTACK body part steps on such a square, it automatically attacks the structure. The default value is false.
+     * @param {boolean} [opts.ignoreRoads] Ignore road structures. Enabling this option can speed up the search. The default value is false. This is only used when the new PathFinder is enabled.
+     * @param {function(string, CostMatrix)} [opts.costCallback] You can use this callback to modify a CostMatrix for any room during the search. The callback accepts two arguments, roomName and costMatrix. Use the costMatrix instance to make changes to the positions costs. If you return a new matrix from this callback, it will be used instead of the built-in cached one. This option is only used when the new PathFinder is enabled.
+     * @param {Array} [opts.ignore] An array of the room's objects or RoomPosition objects which should be treated as walkable tiles during the search. This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     * @param {Array} [opts.avoid] An array of the room's objects or RoomPosition objects which should be treated as obstacles during the search. This option cannot be used when the new PathFinder is enabled (use costCallback option instead).
+     * @param {number} [opts.maxOps] The maximum limit of possible pathfinding operations. You can limit CPU time used for the search based on ratio 1 op ~ 0.001 CPU. The default value is 2000.
+     * @param {number} [opts.heuristicWeight] Weight to apply to the heuristic in the A* formula F = G + weight * H. Use this option only if you understand the underlying A* algorithm mechanics! The default value is 1.2.
+     * @param {boolean} [opts.serialize] If true, the result path will be serialized using Room.serializePath. The default is false.
+     * @param {number} [opts.maxRooms] The maximum allowed rooms to search. The default (and maximum) is 16. This is only used when the new PathFinder is enabled.
+     * @param {number} [opts.range] Find a path to a position in specified linear range of target. The default is 0.
+     * @param {number} [opts.plainCost] Cost for walking on plain positions. The default is 1.
+     * @param {number} [opts.swampCost] Cost for walking on swamp positions. The default is 5.
      *
      * @note Alternative function: findPathTo(target, opts)
      * @param {object} target Can be a RoomPosition object or any object containing RoomPosition.

--- a/Ruin.js
+++ b/Ruin.js
@@ -34,7 +34,7 @@ Ruin.prototype = {
      *
      * @see {@link https://docs.screeps.com/api/#Ruin.store}
      *
-     * @return {Object}
+     * @return {Store}
      */
     store: {},
 

--- a/Store.js
+++ b/Store.js
@@ -1,0 +1,58 @@
+/**
+ * An object that can contain resources in its cargo.
+ * There are two types of stores in the game: general purpose stores and limited stores.
+ *
+ * - General purpose stores can contain any resource within its capacity (e.g. creeps, containers, storages, terminals).
+ * - Limited stores can contain only a few types of resources needed for that particular object (e.g. spawns, extensions, labs, nukers).
+ *
+ * The Store prototype is the same for both types of stores, but they have different behavior depending on the resource argument in its methods.
+ * You can get specific resources from the store by addressing them as object properties:
+ * console.log(creep.store[RESOURCE_ENERGY]);
+ *
+ * @class
+ *
+ * @see {@link https://docs.screeps.com/api/#Store}
+ */
+Store = function() { };
+
+Store.prototype =
+{
+    /**
+     * Returns capacity of this store for the specified resource, or total capacity if resource is undefined.
+     *
+     * @see {@link https://docs.screeps.com/api/#Store.getCapacity}
+     *
+     * @type {function}
+     *
+     * @param {string} [resource] The type of the resource. One of the RESOURCE_* constants.
+     *
+     * @return {number|null} Returns capacity number, or null in case of a not valid resource for this store type.
+     */
+    getCapacity: function(resource) { },
+
+    /**
+     * A shorthand for getCapacity(resource) - getUsedCapacity(resource).
+     *
+     * @see {@link https://docs.screeps.com/api/#Store.getFreeCapacity}
+     *
+     * @type {function}
+     *
+     * @param {string} [resource] The type of the resource. One of the RESOURCE_* constants.
+     *
+     * @return {number|null} Returns free capacity number, or null in case of a not valid resource for this store type.
+     */
+    getFreeCapacity: function(resource) { },
+
+    /**
+     * Returns the capacity used by the specified resource, or total used capacity for general purpose stores if resource is undefined.
+     *
+     * @see {@link https://docs.screeps.com/api/#Store.getUsedCapacity}
+     *
+     * @type {function}
+     *
+     * @param {string} [resource] The type of the resource. One of the RESOURCE_* constants.
+     *
+     * @return {number|null} Returns used capacity number, or null in case of a not valid resource for this store type.
+     */
+    getUsedCapacity: function(resource) { },
+};

--- a/Structures/StructureContainer.js
+++ b/Structures/StructureContainer.js
@@ -15,17 +15,17 @@ StructureContainer.prototype =
 
 
     /**
-     * An object with the structure contents.
-     * Each object key is one of the RESOURCE_* constants, values are resources amounts.
-     * Use _.sum(structure.store) to get the total amount of contents.
+     * A Store object that contains cargo of this structure.
      *
-     * @see {@link http://support.screeps.com/hc/en-us/articles/208435885-StructureContainer#store}
+     * @see {@link https://docs.screeps.com/api/#StructureContainer.store}
      *
-     * @type {Array<string, number>}
+     * @type {Store}
      */
     store: {},
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity()`.
+     *
      * The total amount of resources the structure can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208435885-StructureContainer#storeCapacity}

--- a/Structures/StructureExtension.js
+++ b/Structures/StructureExtension.js
@@ -12,6 +12,8 @@ StructureExtension = function() { };
 StructureExtension.prototype =
 {
     /**
+     * @deprecated Since version 4.x, replaced by `.store[RESOURCE_ENERGY]`.
+     *
      * The amount of energy containing in the extension.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/207711949-StructureExtension#energy}
@@ -21,6 +23,8 @@ StructureExtension.prototype =
     energy: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity(RESOURCE_ENERGY)`.
+     *
      * The total amount of energy the extension can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/207711949-StructureExtension#energyCapacity}
@@ -28,6 +32,15 @@ StructureExtension.prototype =
      * @type {number}
      */
     energyCapacity: 0,
+
+    /**
+     * A Store object that contains cargo of this structure.
+     *
+     * @see {@link https://docs.screeps.com/api/#StructureExtension.store}
+     *
+     * @type {Store}
+     */
+    store: {},
 
     /**
      * @deprecated Since version 2016-07-11, replaced by `Creep.withdraw()`.

--- a/Structures/StructureFactory.js
+++ b/Structures/StructureFactory.js
@@ -34,7 +34,7 @@ StructureFactory.prototype = {
      *
      * @see {@link https://docs.screeps.com/api/#StructureFactory.store}
      *
-     * @return {Object}
+     * @return {Store}
      */
     store: {},
 

--- a/Structures/StructureLab.js
+++ b/Structures/StructureLab.js
@@ -19,6 +19,8 @@ StructureLab.prototype =
     cooldown: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store[RESOURCE_ENERGY]`.
+     *
      * The amount of energy containing in the lab. Energy is used for boosting creeps.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436195-StructureLab#energy}
@@ -28,6 +30,8 @@ StructureLab.prototype =
     energy: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity(RESOURCE_ENERGY)`.
+     *
      * The total amount of energy the lab can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436195-StructureLab#energyCapacity}
@@ -37,6 +41,8 @@ StructureLab.prototype =
     energyCapacity: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `lab.store[lab.mineralType]`.
+     *
      * The amount of mineral resources containing in the lab.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436195-StructureLab#mineralAmount}
@@ -56,6 +62,8 @@ StructureLab.prototype =
     mineralType: "",
 
     /**
+     * @deprecated Since version 4.x, replaced by `lab.store.getCapacity(lab.mineralType || yourMineral)`.
+     *
      * The total amount of minerals the lab can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436195-StructureLab#mineralCapacity}
@@ -63,6 +71,15 @@ StructureLab.prototype =
      * @type {number}
      */
     mineralCapacity: 0,
+
+    /**
+     * A Store object that contains cargo of this structure.
+     *
+     * @see {@link https://docs.screeps.com/api/#StructureLab.store}
+     *
+     * @type {Store}
+     */
+    store: {},
 
     /**
      * Boosts creep body part using the containing mineral compound.

--- a/Structures/StructureLink.js
+++ b/Structures/StructureLink.js
@@ -20,6 +20,8 @@ StructureLink.prototype =
     cooldown: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store[RESOURCE_ENERGY]`.
+     *
      * The amount of energy containing in the link.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436275-StructureLink#energy}
@@ -29,6 +31,8 @@ StructureLink.prototype =
     energy: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity(RESOURCE_ENERGY)`.
+     *
      * The total amount of energy the link can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436275-StructureLink#energyCapacity}
@@ -36,6 +40,15 @@ StructureLink.prototype =
      * @type {number}
      */
     energyCapacity: 0,
+
+    /**
+     * A Store object that contains cargo of this structure.
+     *
+     * @see {@link https://docs.screeps.com/api/#StructureLink.store}
+     *
+     * @type {Store}
+     */
+    store: {},
 
     /**
      * Transfer energy from the link to another link or a creep.

--- a/Structures/StructureNuker.js
+++ b/Structures/StructureNuker.js
@@ -14,6 +14,8 @@ StructureNuker = function() { };
 StructureNuker.prototype =
 {
     /**
+     * @deprecated Since version 4.x, replaced by `.store[RESOURCE_ENERGY]`.
+     *
      * The amount of energy containing in this structure.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208488255-StructureNuker#energy}
@@ -23,6 +25,8 @@ StructureNuker.prototype =
     energy: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity(RESOURCE_ENERGY)`.
+     *
      * The total amount of energy this structure can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208488255-StructureNuker#energyCapacity}
@@ -32,6 +36,8 @@ StructureNuker.prototype =
     energyCapacity: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store[RESOURCE_GHODIUM]`.
+     *
      * The amount of ghodium containing in this structure.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208488255-StructureNuker#ghodium}
@@ -41,6 +47,8 @@ StructureNuker.prototype =
     ghodium: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity(RESOURCE_GHODIUM)`.
+     *
      * The total amount of ghodium this structure can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208488255-StructureNuker#ghodiumCapacity}
@@ -57,6 +65,15 @@ StructureNuker.prototype =
      * @type {number}
      */
     cooldown: 0,
+
+    /**
+     * A Store object that contains cargo of this structure.
+     *
+     * @see {@link https://docs.screeps.com/api/#StructureNuker.store}
+     *
+     * @type {Store}
+     */
+    store: {},
 
     /**
      * Launch a nuke to the specified position.

--- a/Structures/StructurePowerSpawn.js
+++ b/Structures/StructurePowerSpawn.js
@@ -11,6 +11,8 @@ StructurePowerSpawn = function() { };
 StructurePowerSpawn.prototype =
 {
     /**
+     * @deprecated Since version 4.x, replaced by `.store[RESOURCE_ENERGY]`.
+     *
      * The amount of energy containing in this structure.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436585-StructurePowerSpawn#energy}
@@ -20,6 +22,8 @@ StructurePowerSpawn.prototype =
     energy: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity(RESOURCE_ENERGY)`.
+     *
      * The total amount of energy this structure can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436585-StructurePowerSpawn#energyCapacity}
@@ -29,6 +33,8 @@ StructurePowerSpawn.prototype =
     energyCapacity: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store[RESOURCE_POWER]`.
+     *
      * The amount of power containing in this structure.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436585-StructurePowerSpawn#power}
@@ -38,6 +44,8 @@ StructurePowerSpawn.prototype =
     power: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity(RESOURCE_POWER)`.
+     *
      * The total amount of power this structure can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436585-StructurePowerSpawn#powerCapacity}
@@ -45,6 +53,15 @@ StructurePowerSpawn.prototype =
      * @type {number}
      */
     powerCapacity: 0,
+
+    /**
+     * A Store object that contains cargo of this structure.
+     *
+     * @see {@link https://docs.screeps.com/api/#StructurePowerSpawn.store}
+     *
+     * @type {Store}
+     */
+    store: {},
 
     /**
      * Create a power creep.

--- a/Structures/StructureSpawn.js
+++ b/Structures/StructureSpawn.js
@@ -23,6 +23,8 @@ Spawn.prototype = StructureSpawn.prototype;
 StructureSpawn.prototype =
 {
     /**
+     * @deprecated Since version 4.x, replaced by `.store[RESOURCE_ENERGY]`.
+     *
      * The amount of energy containing in the spawn.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/205990342-StructureSpawn#energy}
@@ -32,6 +34,8 @@ StructureSpawn.prototype =
     energy: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity(RESOURCE_ENERGY)`.
+     *
      * The total amount of energy the spawn can contain
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/205990342-StructureSpawn#energyCapacity}
@@ -69,6 +73,15 @@ StructureSpawn.prototype =
      * @type {object|null}
      */
     spawning: null,
+
+    /**
+     * A Store object that contains cargo of this structure.
+     *
+     * @see {@link https://docs.screeps.com/api/#StructureSpawn.store}
+     *
+     * @type {Store}
+     */
+    store: {},
 
     /**
      * Check if a creep can be created.

--- a/Structures/StructureStorage.js
+++ b/Structures/StructureStorage.js
@@ -12,17 +12,17 @@ StructureStorage = function() { };
 StructureStorage.prototype =
 {
     /**
-     * An object with the storage contents.
-     * Each object key is one of the RESOURCE_* constants, values are resources amounts.
-     * Use _.sum(structure.store) to get the total amount of contents.
+     * A Store object that contains cargo of this structure.
      *
-     * @see {@link http://support.screeps.com/hc/en-us/articles/208436805-StructureStorage#store}
+     * @see {@link https://docs.screeps.com/api/#StructureStorage.store}
      *
-     * @type {Array<string, number>}
+     * @type {Store}
      */
     store: {},
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity()`.
+     *
      * The total amount of resources the storage can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208436805-StructureStorage#storeCapacity}

--- a/Structures/StructureTerminal.js
+++ b/Structures/StructureTerminal.js
@@ -17,17 +17,17 @@ StructureTerminal = function() { };
 StructureTerminal.prototype =
 {
     /**
-     * An object with the storage contents.
-     * Each object key is one of the RESOURCE_* constants, values are resources amounts.
-     * Use _.sum(structure.store) to get the total amount of contents.
+     * A Store object that contains cargo of this structure.
      *
-     * @see {@link http://support.screeps.com/hc/en-us/articles/207713399-StructureTerminal#store}
+     * @see {@link https://docs.screeps.com/api/#StructureTerminal.store}
      *
-     * @type {Array<string, number>}
+     * @type {Store}
      */
     store: {},
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity()`.
+     *
      * The total amount of resources the storage can contain.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/207713399-StructureTerminal#storeCapacity}

--- a/Structures/StructureTower.js
+++ b/Structures/StructureTower.js
@@ -14,6 +14,7 @@ StructureTower = function() { };
 StructureTower.prototype =
 {
     /**
+     * @deprecated Since version 4.x, replaced by `.store[RESOURCE_ENERGY]`.
      *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208437105-StructureTower#energy}
      *
@@ -22,11 +23,22 @@ StructureTower.prototype =
     energy: 0,
 
     /**
+     * @deprecated Since version 4.x, replaced by `.store.getCapacity(RESOURCE_ENERGY)`.
+     *
      * @see {@link http://support.screeps.com/hc/en-us/articles/208437105-StructureTower#energyCapacity}
      *
      * @type {number}
      */
     energyCapacity: 0,
+
+    /**
+     * A Store object that contains cargo of this structure.
+     *
+     * @see {@link https://docs.screeps.com/api/#StructureTower.store}
+     *
+     * @type {Store}
+     */
+    store: {},
 
     /**
      * Remotely attack any creep in the room.

--- a/Tombstone.js
+++ b/Tombstone.js
@@ -38,11 +38,11 @@ Tombstone.prototype =
     id: "",
 
     /**
-     * An object with the tombstone contents. Each object key is one of the RESOURCE_* constants, values are resources amounts. RESOURCE_ENERGY is always defined and equals to 0 when empty, other resources are undefined when empty. You can use lodash.sum to get the total amount of contents.
+     * A Store object that contains cargo of this structure.
      *
      * @see {@link https://docs.screeps.com/api/#Tombstone.store}
      *
-     * @type {object}
+     * @type {Store}
      */
     store: { },
 


### PR DESCRIPTION
Also add visualizePathStyle and its members

Methods that accept both x, y and RoomPosition can further be improved by adding multiple doc comments [like so](https://github.com/jsdoc3/jsdoc/issues/1329#issuecomment-282136221) but my WebStorm currently doesn't support multiple doc comments so I can't verify it. 